### PR TITLE
Flexibiliza troca de colunas de códigos por nomes legíveis

### DIFF
--- a/macros/utilidades/filtrar_regex.sql
+++ b/macros/utilidades/filtrar_regex.sql
@@ -1,0 +1,18 @@
+{#
+SPDX-FileCopyrightText: 2022 ImpulsoGov <contato@impulsogov.org>
+
+SPDX-License-Identifier: MIT
+#}
+
+
+
+{%- macro filtrar_regex(iteravel, expressao_regular) -%}
+{% set re = modules.re %}
+{% set filtrado = [] %}
+{%- for texto in iteravel -%}
+{%- if re.match(expressao_regular, texto) -%}
+{%- set _ = filtrado.append(texto) -%}
+{%- endif -%}
+{%- endfor -%}
+{{- return(filtrado) -}}
+{%- endmacro -%}

--- a/macros/utilidades/filtrar_regex.yml
+++ b/macros/utilidades/filtrar_regex.yml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2022 Impulso Gov <contato@impulsogov.org>
+#
+# SPDX-License-Identifier: MIT
+
+
+version: 2
+
+macros:
+
+  - name: filtrar_regex
+    description: >
+      A partir de um iterável e um padrão de expressão regular, retorna uma
+      lista apenas com os elementos que correspondem ao padrão.
+
+    docs:
+      show: true
+
+    arguments:
+      - name: iteravel
+        type: Iterable[str]
+        description: >
+          Lista ou outro iterável cujos elementos sejam todos textos a serem
+          comparados com um padrão de expressão regular. 
+
+      - name: expressao_regular
+        type: str
+        description: >
+          Texto com padrão de
+          [expressão regular](https://docs.python.org/3/library/re.html)
+          nativo do Python, que será comparado com os elementos do iterável de
+          entrada e filtrar os que devem aparecer na lista de saída.

--- a/macros/utilidades/nomear_estabelecimentos.sql
+++ b/macros/utilidades/nomear_estabelecimentos.sql
@@ -13,6 +13,15 @@ SPDX-License-Identifier: MIT
     todos_estabelecimentos_valor="Todos",
     cte_resultado="com_nomes_estabelecimentos"
 ) %}
+{%- set re = modules.re -%}
+{%- set lista_de_codigos_colunas = adapter.get_columns_in_relation(
+    source("codigos", "estabelecimentos")
+) -%}
+{%- set lista_de_codigos_coluna_id = "estabelecimento" + re.match(
+        ".*estabelecimento.*(_id.*)",
+        coluna_estabelecimento_id
+    ).groups(1)[0]
+ -%}
 {{ cte_resultado }} AS (
 SELECT
     t.*,
@@ -20,7 +29,8 @@ SELECT
     (
         CASE
             WHEN
-            {{ coluna_estabelecimento_id }} = '{{ todos_estabelecimentos_id }}'
+                t.{{ coluna_estabelecimento_id }}
+                = '{{ todos_estabelecimentos_id }}'
             THEN '{{ todos_estabelecimentos_valor }}'
         ELSE
 {%- endif %}    coalesce(
@@ -29,18 +39,18 @@ SELECT
             )
     {%- if todos_sexos_id is not none -%}
         END
-    ){%- endif %} AS {{ coluna_estabelecimento_nome}}
+    ){%- endif %} AS {{ coluna_estabelecimento_nome }}
 FROM {{ relacao }} t
 LEFT JOIN (
     SELECT 
-    {%- for coluna in adapter.get_columns_in_relation(
-        source("codigos", "estabelecimentos")
-    ) %}
+    {%- for coluna in lista_de_codigos_colunas %}
         {{coluna.quoted}} AS "estabelecimento_{{coluna.name}}"
         {{- "," if not loop.last }}
     {%- endfor %}
     FROM {{ source("codigos", "estabelecimentos") }}
 ) estabelecimento
-USING ({{ coluna_estabelecimento_id }})
+ON 
+    t.{{ coluna_estabelecimento_id }}
+    = estabelecimento.{{ lista_de_codigos_coluna_id }}
 )
 {%- endmacro -%}

--- a/macros/utilidades/nomear_racas_cores.sql
+++ b/macros/utilidades/nomear_racas_cores.sql
@@ -13,6 +13,14 @@ SPDX-License-Identifier: MIT
     todos_raca_cor_valor="Todos",
     cte_resultado="com_nomes_racas_cores"
 ) %}
+{%- set re = modules.re -%}
+{%- set lista_de_codigos_colunas = adapter.get_columns_in_relation(
+    source("codigos", "racas_cores")
+) -%}
+{%- set lista_de_codigos_coluna_id = (
+    "raca_cor"
+    + re.match(".*raca_cor.*(_id.*)", coluna_raca_cor_id).groups(1)[0]
+) -%}
 {{ cte_resultado }} AS (
 SELECT
     t.*,
@@ -20,24 +28,22 @@ SELECT
     (
         CASE
             WHEN
-            {{ coluna_raca_cor_id }} = '{{ todos_racas_cores_id }}'
-            THEN '{{ todos_racas_cores_valor }}'
+            t.{{ coluna_raca_cor_id }} = '{{ todas_racas_cores_id }}'
+            THEN '{{ todas_racas_cores_valor }}'
         ELSE
 {%- endif %}    raca_cor.raca_cor_nome
     {%- if todos_racas_cores_id is not none -%}
         END
-    ){%- endif %} AS {{ coluna_raca_cor_nome}}
+    ){%- endif %} AS {{ coluna_raca_cor_nome }}
 FROM {{ relacao }} t
 LEFT JOIN (
     SELECT 
-    {%- for coluna in adapter.get_columns_in_relation(
-        source("codigos", "racas_cores")
-    ) %}
+    {%- for coluna in lista_de_codigos_colunas %}
         {{coluna.quoted}} AS "raca_cor_{{coluna.name}}"
         {{- "," if not loop.last }}
     {%- endfor %}
     FROM {{ source("codigos", "racas_cores") }}
 ) raca_cor
-USING ({{ coluna_raca_cor_id }})
+ON t.{{ coluna_raca_cor_id }} = raca_cor.{{ lista_de_codigos_coluna_id }}
 )
 {%- endmacro -%}

--- a/macros/utilidades/nomear_sexos.sql
+++ b/macros/utilidades/nomear_sexos.sql
@@ -13,6 +13,13 @@ SPDX-License-Identifier: MIT
     todos_sexos_valor="Todos",
     cte_resultado="com_nomes_sexos"
 ) %}
+{%- set re = modules.re -%}
+{%- set lista_de_codigos_colunas = adapter.get_columns_in_relation(
+    source("codigos", "sexos")
+) -%}
+{%- set lista_de_codigos_coluna_id = (
+    "sexo" + re.match(".*sexo.*(_id.*)", coluna_sexo_id).groups(1)[0]
+) -%}
 {{ cte_resultado }} AS (
 SELECT
     t.*,
@@ -20,24 +27,22 @@ SELECT
     (
         CASE
             WHEN
-            {{ coluna_sexo_id }} = '{{ todos_sexos_id }}'
+            t.{{ coluna_sexo_id }} = '{{ todos_sexos_id }}'
             THEN '{{ todos_sexos_valor }}'
         ELSE
 {%- endif %}    sexo.sexo_nome
     {%- if todos_sexos_id is not none -%}
         END
-    ){%- endif %} AS {{ coluna_sexo_nome}}
+    ){%- endif %} AS {{ coluna_sexo_nome }}
 FROM {{ relacao }} t
 LEFT JOIN (
     SELECT 
-    {%- for coluna in adapter.get_columns_in_relation(
-        source("codigos", "sexos")
-    ) %}
+    {%- for coluna in lista_de_codigos_colunas %}
         {{coluna.quoted}} AS "sexo_{{coluna.name}}"
         {{- "," if not loop.last }}
     {%- endfor %}
     FROM {{ source("codigos", "sexos") }}
 ) sexo
-USING ({{ coluna_sexo_id }})
+ON t.{{ coluna_sexo_id }} = sexo.{{ lista_de_codigos_coluna_id }}
 )
 {%- endmacro -%}

--- a/models/caps/usuarios_ativos/_caps_usuarios_ativos_por_estabelecimento_resumo.sql
+++ b/models/caps/usuarios_ativos/_caps_usuarios_ativos_por_estabelecimento_resumo.sql
@@ -125,7 +125,7 @@ resumo AS (
 		(
 			tornandose_inativos - tornandose_inativos_anterior
 		) AS dif_tornandose_inativos_anterior,
-        sexo_predominante.sexo_predominante_id_sigtap AS sexo_id_sigtap,
+        sexo_predominante.sexo_predominante_id_sigtap,
         sexo_predominante.sexo_predominante_quantidade,
         idade_media.usuarios_idade_media,
 		now() AS atualizacao_data
@@ -148,7 +148,7 @@ resumo AS (
 	)
 ),
 {{ ultimas_competencias(
-    relacao="final",
+    relacao="resumo",
     fontes=[
 		"raas_psicossocial_disseminacao",
 		"bpa_i_disseminacao"


### PR DESCRIPTION
Flexibiliza as suposições feitas anteriormente sobre a estrutura de tabelas sobre as quais se aplica a macro [`preparar_uso_externo()`](https://impulsogov.github.io/saude-mental-indicadores/#!/macro/macro.impulso_saude_mental.preparar_uso_externo) (ver #9 ).

Este PR adiciona uma nova macro (`filtrar_regex()`) que filtra um iterável deixando apenas os elementos que coincidem com uma expressão regular. 

Essa macro e mais uma série de modificações nas macros `preparar_uso_externo()`, `nomear_sexos()`, `nomear_racas_cores()` e `nomear_estabelecimentos()` são usadas para garantir que qualquer coluna com códigos de categoria de sexo, raça/cor ou estabelecimento seja adequadamente processada ao se aplicar a macro `preparar_uso_externo()`, substituindo a coluna de código identificador por um nome legível para humanos.

Closes #9 .

TODO: Os trechos de macros modificados por este PR (`preparar_uso_externo()` e `nomear_*()`) apresentam bastante semelhança/repetição, e provavelmente podem ser refatorados em um PR futuro para garantir mais economia de código e facilidade de manutenção.