### PR TITLE
Adiciona modelos de encaminhamentos da APS para CAPS e especializada

### DIFF
--- a/models/encaminhamentos_aps/aps_caps/_encaminhamentos_aps_caps.sql
+++ b/models/encaminhamentos_aps/aps_caps/_encaminhamentos_aps_caps.sql
@@ -1,0 +1,47 @@
+{#
+SPDX-FileCopyrightText: 2022 ImpulsoGov <contato@impulsogov.org>
+ 
+SPDX-License-Identifier: MIT
+#}
+
+
+WITH
+sisab_producao_por_conduta AS (
+    SELECT * FROM {{ source('sisab', 'sisab_producao_conduta_problema_condicao') }}
+),
+saude_mental_encaminhamentos_especializada AS (
+    SELECT
+)
+
+
+
+
+
+
+
+
+
+{{ juntar_periodos_consecutivos(
+    relacao="_reducao_danos_acoes_subtotais",
+    agrupar_por=[
+        "unidade_geografica_id",
+        "unidade_geografica_id_sus",
+        "estabelecimento_id_scnes",
+        "profissional_vinculo_ocupacao_id_cbo2002"
+    ],
+    colunas_valores=[
+        "quantidade_registrada",
+    ],
+    periodo_tipo="Mensal",
+    coluna_periodo="periodo_id",    
+    colunas_adicionais_periodo=[
+        "periodo_data_inicio"
+        ],
+    cte_resultado="com_periodo_anterior"
+) }},
+{{ ultimas_competencias(
+    relacao="com_periodo_anterior",
+    fontes=["procedimentos_disseminacao"],
+    meses_antes_ultima_competencia=(0, none),
+    cte_resultado="ate_ultima_competencia"
+) }},

--- a/models/encaminhamentos_aps/aps_caps/_encaminhamentos_aps_caps.sql
+++ b/models/encaminhamentos_aps/aps_caps/_encaminhamentos_aps_caps.sql
@@ -9,25 +9,72 @@ WITH
 sisab_producao_por_conduta AS (
     SELECT * FROM {{ source('sisab', 'sisab_producao_conduta_problema_condicao') }}
 ),
+periodos AS (
+    SELECT * FROM {{ source('codigos', 'periodos') }}
+),
+unidades_geograficas AS (
+    SELECT * FROM {{ source('codigos', 'unidades_geograficas') }}
+),
 saude_mental_encaminhamentos_especializada AS (
     SELECT
-)
-
-
-
-
-
-
-
-
-
+        unidade_geografica_id,
+        periodo_id,
+        sum(quantidade_registrada) AS quantidade_registrada,
+        'Encaminhamento para CAPS' AS conduta
+    FROM sisab_producao_por_conduta
+    WHERE 
+        conduta  = 'Encaminhamento p/ CAPS'
+    AND problema_condicao_avaliada 
+        = ANY (ARRAY[
+            'Saúde mental'::text,
+            'Usuário de álcool'::text,
+            'Usuário de outras drogas'::TEXT
+        ])
+    GROUP BY 
+        unidade_geografica_id,
+        periodo_id
+),
+saude_mental_todas_condutas AS (
+    SELECT
+        unidade_geografica_id,
+        periodo_id,
+        sum(quantidade_registrada) AS quantidade_registrada,
+        'Todas' AS conduta
+    FROM sisab_producao_por_conduta
+    WHERE problema_condicao_avaliada = ANY (ARRAY[
+        'Saúde mental',
+        'Usuário de álcool',
+        'Usuário de outras drogas'
+    ])
+    GROUP BY 
+        unidade_geografica_id,
+        periodo_id
+),
+saude_mental_condutas AS (
+    SELECT * FROM saude_mental_encaminhamentos_especializada
+    UNION
+    SELECT * FROM saude_mental_todas_condutas
+),
+saude_mental_condutas_joins AS (
+    SELECT 
+        saude_mental_condutas.unidade_geografica_id,
+        unidades_geograficas.id_sus AS unidade_geografica_id_sus,
+        periodos.data_inicio AS periodo_data_inicio,
+        saude_mental_condutas.periodo_id,
+        saude_mental_condutas.conduta,
+        saude_mental_condutas.quantidade_registrada
+    FROM saude_mental_condutas
+    LEFT JOIN periodos 
+    ON saude_mental_condutas.periodo_id = periodos.id
+    LEFT JOIN unidades_geograficas
+    ON saude_mental_condutas.unidade_geografica_id = unidades_geograficas.id
+),
 {{ juntar_periodos_consecutivos(
-    relacao="_reducao_danos_acoes_subtotais",
+    relacao="saude_mental_condutas_joins",
     agrupar_por=[
         "unidade_geografica_id",
         "unidade_geografica_id_sus",
-        "estabelecimento_id_scnes",
-        "profissional_vinculo_ocupacao_id_cbo2002"
+        "conduta"
     ],
     colunas_valores=[
         "quantidade_registrada",
@@ -41,7 +88,29 @@ saude_mental_encaminhamentos_especializada AS (
 ) }},
 {{ ultimas_competencias(
     relacao="com_periodo_anterior",
-    fontes=["procedimentos_disseminacao"],
+    fontes=["sisab_producao_conduta_problema_condicao"],
     meses_antes_ultima_competencia=(0, none),
     cte_resultado="ate_ultima_competencia"
 ) }},
+final AS (
+    SELECT
+        {{ dbt_utils.surrogate_key([
+            "unidade_geografica_id",
+            "periodo_id",
+            "conduta"
+        ]) }} AS id,
+        unidade_geografica_id,
+        unidade_geografica_id_sus,
+        periodo_data_inicio,
+        periodo_id,
+        conduta,
+        quantidade_registrada,
+        quantidade_registrada_anterior,
+        (
+            coalesce(quantidade_registrada, 0)
+            - coalesce(quantidade_registrada_anterior, 0)
+        ) AS dif_quantidade_registrada_anterior,
+        now() AS atualizacao_data   
+    FROM ate_ultima_competencia
+)  
+SELECT * FROM final

--- a/models/encaminhamentos_aps/aps_caps/_encaminhamentos_aps_caps.yml
+++ b/models/encaminhamentos_aps/aps_caps/_encaminhamentos_aps_caps.yml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2022 Impulso Gov <contato@impulsogov.org>
+#
+# SPDX-License-Identifier: MIT
+
+
+version: 2
+
+models:
+  - name: _encaminhamentos_aps_caps
+    description: >
+      **Modelo para uso interno no dbt**. Ver modelo 'encaminhamentos_aps_caps' para a versão final.
+    config:
+      grants:
+        select: ['saude_mental_analistas', 'saude_mental_integracao'] 
+      alias: _encaminhamentos_aps_caps
+      enabled: true
+      indexes:
+        - columns:
+          - "id"
+          unique: true
+        - columns:
+          - "unidade_geografica_id_sus"
+          - "unidade_geografica_id"
+      materialized: view
+      persist_docs:
+        relation: true
+      tags:
+        - "saude_mental"
+        - "sisab"
+        - "encaminhamentos_aps"
+      unique_key: "id"

--- a/models/encaminhamentos_aps/aps_caps/encaminhamentos_aps_caps.sql
+++ b/models/encaminhamentos_aps/aps_caps/encaminhamentos_aps_caps.sql
@@ -1,0 +1,14 @@
+{#
+SPDX-FileCopyrightText: 2022 ImpulsoGov <contato@impulsogov.org>
+ 
+SPDX-License-Identifier: MIT
+#}
+
+-- depends_on: {{ ref('_encaminhamentos_aps_caps') }}
+
+WITH
+{{ preparar_uso_externo(
+	relacao="_encaminhamentos_aps_caps",
+	cte_resultado="final"
+) }}
+SELECT * FROM final

--- a/models/encaminhamentos_aps/aps_caps/encaminhamentos_aps_caps.yml
+++ b/models/encaminhamentos_aps/aps_caps/encaminhamentos_aps_caps.yml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2022 Impulso Gov <contato@impulsogov.org>
+#
+# SPDX-License-Identifier: MIT
+
+
+version: 2
+
+models:
+  - name: encaminhamentos_aps_caps
+    description: >
+      Quantidade de atendimentos individuais em saúde mental realizadas 
+      por equipes da Atenção Primária em Saúde por município e por mês, 
+      e quantidade desses atendimentos que tiveram como desfecho o 
+      encaminhamento para CAPS.
+    config:
+      grants:
+        select: ['saude_mental_analistas', 'saude_mental_integracao'] 
+      alias: encaminhamentos_aps_caps
+      enabled: true
+      indexes:
+        - columns:
+          - "unidade_geografica_id_sus"
+          - "unidade_geografica_id"
+      materialized: view
+      persist_docs:
+        relation: true
+      tags:
+        - "saude_mental"
+        - "sisab"
+        - "encaminhamentos_aps"
+      unique_key: "id"

--- a/models/encaminhamentos_aps/aps_caps/encaminhamentos_aps_caps_resumo_ultimo_mes_horizontal.sql
+++ b/models/encaminhamentos_aps/aps_caps/encaminhamentos_aps_caps_resumo_ultimo_mes_horizontal.sql
@@ -1,0 +1,73 @@
+{#
+SPDX-FileCopyrightText: 2022 ImpulsoGov <contato@impulsogov.org>
+ 
+SPDX-License-Identifier: MIT
+#}
+
+
+WITH
+encaminhamentos_aps_caps AS (
+    SELECT * FROM {{ ref('encaminhamentos_aps_caps') }}
+),
+relacao_aps_caps AS (
+SELECT
+    DISTINCT ON (
+        unidade_geografica_id,
+        unidade_geografica_id_sus,
+        conduta
+    )
+    *
+FROM saude_mental.encaminhamentos_aps_caps
+ORDER BY 
+    unidade_geografica_id,
+    unidade_geografica_id_sus,
+    conduta,
+    competencia DESC
+),
+relacao_aps_caps_horizontalizado AS (
+    SELECT
+        unidade_geografica_id,
+        unidade_geografica_id_sus,
+        periodo_id,
+        competencia,
+        nome_mes,
+        sum(quantidade_registrada) FILTER (
+            WHERE conduta = 'Encaminhamento para CAPS'
+        ) AS encaminhamentos_caps,
+        sum(quantidade_registrada_anterior) FILTER (
+            WHERE conduta = 'Encaminhamento para CAPS'
+        ) AS encaminhamentos_caps_anterior,
+        sum(quantidade_registrada) FILTER (
+            WHERE conduta = 'Todas'
+        ) AS atendimentos_sm_aps,
+        sum(quantidade_registrada_anterior) FILTER (
+            WHERE conduta = 'Todas'
+        ) AS atendimentos_sm_aps_anterior
+    FROM relacao_aps_caps
+    GROUP BY 
+        unidade_geografica_id,
+        unidade_geografica_id_sus,
+        periodo_id,
+        competencia,
+        nome_mes
+),
+final AS (
+    SELECT
+        unidade_geografica_id,
+        unidade_geografica_id_sus,
+        periodo_id,
+        competencia,
+        nome_mes,
+        encaminhamentos_caps,
+        atendimentos_sm_aps,
+        round(
+            100 * encaminhamentos_caps
+            / nullif(atendimentos_sm_aps, 0),
+            2
+        ) AS perc_encaminhamentos_caps,
+        (
+            encaminhamentos_caps - encaminhamentos_caps_anterior
+        ) AS dif_encaminhamentos_caps_anterior
+    FROM relacao_aps_caps_horizontalizado
+)
+SELECT * FROM final

--- a/models/encaminhamentos_aps/aps_caps/encaminhamentos_aps_caps_resumo_ultimo_mes_horizontal.yml
+++ b/models/encaminhamentos_aps/aps_caps/encaminhamentos_aps_caps_resumo_ultimo_mes_horizontal.yml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2022 Impulso Gov <contato@impulsogov.org>
+#
+# SPDX-License-Identifier: MIT
+
+
+version: 2
+
+models:
+  - name: encaminhamentos_aps_caps_resumo_ultimo_mes_horizontal
+    description: >
+      Quantidade de atendimentos individuais em saúde mental realizadas 
+      por equipes da Atenção Primária em Saúde por município na última 
+      competência com dados disponíveis, e quantidade desses atendimentos 
+      que tiveram como desfecho o encaminhamento para CAPS.
+    config:
+      grants:
+        select: ['saude_mental_analistas', 'saude_mental_integracao'] 
+      alias: encaminhamentos_aps_caps_resumo_ultimo_mes_horizontal
+      enabled: true
+      indexes:
+        - columns:
+          - "id"
+          unique: true
+        - columns:
+          - "unidade_geografica_id_sus"
+          - "unidade_geografica_id"
+      materialized: view
+      persist_docs:
+        relation: true
+      tags:
+        - "saude_mental"
+        - "sisab"
+        - "encaminhamentos_aps"
+      unique_key: "id"

--- a/models/encaminhamentos_aps/aps_especializada/_encaminhamentos_aps_especializada.sql
+++ b/models/encaminhamentos_aps/aps_especializada/_encaminhamentos_aps_especializada.sql
@@ -1,0 +1,51 @@
+{#
+SPDX-FileCopyrightText: 2022 ImpulsoGov <contato@impulsogov.org>
+ 
+SPDX-License-Identifier: MIT
+#}
+
+
+WITH
+sisab_producao_por_conduta AS (
+    SELECT * FROM {{ source('sisab', 'sisab_producao_conduta_problema_condicao') }}
+),
+saude_mental_encaminhamentos_especializada AS (
+    SELECT
+        unidade_geografica_id,
+        periodo_id,
+        sum(quantidade_registrada) AS quantidade_registrada,
+        'Encaminhamento para serviço especializado' AS conduta
+    FROM sisab_producao_por_conduta
+    WHERE 
+        conduta  = 'Encaminhamento p/ serviço especializado'
+    AND problema_condicao_avaliada 
+        = ANY (ARRAY[
+            'Saúde mental'::text,
+            'Usuário de álcool'::text,
+            'Usuário de outras drogas'::TEXT
+        ])
+    GROUP BY 
+        unidade_geografica_id,
+        periodo_id
+),
+saude_mental_todas_condutas AS (
+    SELECT
+        unidade_geografica_id,
+        periodo_id,
+        sum(quantidade_registrada) AS quantidade_registrada,
+        'Todas' AS conduta
+    FROM sisab_producao_por_conduta
+    WHERE problema_condicao_avaliada = ANY (ARRAY[
+        'Saúde mental',
+        'Usuário de álcool',
+        'Usuário de outras drogas'
+    ])
+    GROUP BY 
+        unidade_geografica_id,
+        periodo_id
+),
+saude_mental_condutas AS (
+    SELECT * FROM saude_mental_encaminhamentos_especializada
+    UNION
+    SELECT * FROM saude_mental_todas_condutas
+)

--- a/models/encaminhamentos_aps/aps_especializada/_encaminhamentos_aps_especializada.sql
+++ b/models/encaminhamentos_aps/aps_especializada/_encaminhamentos_aps_especializada.sql
@@ -9,6 +9,12 @@ WITH
 sisab_producao_por_conduta AS (
     SELECT * FROM {{ source('sisab', 'sisab_producao_conduta_problema_condicao') }}
 ),
+periodos AS (
+    SELECT * FROM {{ source('codigos', 'periodos') }}
+),
+unidades_geograficas AS (
+    SELECT * FROM {{ source('codigos', 'unidades_geograficas') }}
+),
 saude_mental_encaminhamentos_especializada AS (
     SELECT
         unidade_geografica_id,
@@ -48,4 +54,63 @@ saude_mental_condutas AS (
     SELECT * FROM saude_mental_encaminhamentos_especializada
     UNION
     SELECT * FROM saude_mental_todas_condutas
-)
+),
+saude_mental_condutas_joins AS (
+    SELECT 
+        saude_mental_condutas.unidade_geografica_id,
+        unidades_geograficas.id_sus AS unidade_geografica_id_sus,
+        periodos.data_inicio AS periodo_data_inicio,
+        saude_mental_condutas.periodo_id,
+        saude_mental_condutas.conduta,
+        saude_mental_condutas.quantidade_registrada
+    FROM saude_mental_condutas
+    LEFT JOIN periodos 
+    ON saude_mental_condutas.periodo_id = periodos.id
+    LEFT JOIN unidades_geograficas
+    ON saude_mental_condutas.unidade_geografica_id = unidades_geograficas.id
+),
+{{ juntar_periodos_consecutivos(
+    relacao="saude_mental_condutas_joins",
+    agrupar_por=[
+        "unidade_geografica_id",
+        "unidade_geografica_id_sus",
+        "conduta"
+    ],
+    colunas_valores=[
+        "quantidade_registrada",
+    ],
+    periodo_tipo="Mensal",
+    coluna_periodo="periodo_id",    
+    colunas_adicionais_periodo=[
+        "periodo_data_inicio"
+        ],
+    cte_resultado="com_periodo_anterior"
+) }},
+{{ ultimas_competencias(
+    relacao="com_periodo_anterior",
+    fontes=["sisab_producao_conduta_problema_condicao"],
+    meses_antes_ultima_competencia=(0, none),
+    cte_resultado="ate_ultima_competencia"
+) }},
+final AS (
+    SELECT
+        {{ dbt_utils.surrogate_key([
+            "unidade_geografica_id",
+            "periodo_id",
+            "conduta"
+        ]) }} AS id,
+        unidade_geografica_id,
+        unidade_geografica_id_sus,
+        periodo_data_inicio,
+        periodo_id,
+        conduta,
+        quantidade_registrada,
+        quantidade_registrada_anterior,
+        (
+            coalesce(quantidade_registrada, 0)
+            - coalesce(quantidade_registrada_anterior, 0)
+        ) AS dif_quantidade_registrada_anterior,
+        now() AS atualizacao_data   
+    FROM ate_ultima_competencia
+)  
+SELECT * FROM final

--- a/models/encaminhamentos_aps/aps_especializada/_encaminhamentos_aps_especializada.yml
+++ b/models/encaminhamentos_aps/aps_especializada/_encaminhamentos_aps_especializada.yml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2022 Impulso Gov <contato@impulsogov.org>
+#
+# SPDX-License-Identifier: MIT
+
+
+version: 2
+
+models:
+  - name: _encaminhamentos_aps_especializada
+    description: >
+      **Modelo para uso interno no dbt**. Ver modelo 'encaminhamentos_aps_especializada' para a versão final.
+    config:
+      grants:
+        select: ['saude_mental_analistas', 'saude_mental_integracao'] 
+      alias: _encaminhamentos_aps_especializada
+      enabled: true
+      indexes:
+        - columns:
+          - "id"
+          unique: true
+        - columns:
+          - "unidade_geografica_id_sus"
+          - "unidade_geografica_id"
+      materialized: view
+      persist_docs:
+        relation: true
+      tags:
+        - "saude_mental"
+        - "sisab"
+        - "encaminhamentos_aps"
+      unique_key: "id"

--- a/models/encaminhamentos_aps/aps_especializada/encaminhamentos_aps_especializada.sql
+++ b/models/encaminhamentos_aps/aps_especializada/encaminhamentos_aps_especializada.sql
@@ -1,0 +1,14 @@
+{#
+SPDX-FileCopyrightText: 2022 ImpulsoGov <contato@impulsogov.org>
+ 
+SPDX-License-Identifier: MIT
+#}
+
+-- depends_on: {{ ref('_encaminhamentos_aps_especializada') }}
+
+WITH
+{{ preparar_uso_externo(
+	relacao="_encaminhamentos_aps_especializada",
+	cte_resultado="final"
+) }}
+SELECT * FROM final

--- a/models/encaminhamentos_aps/aps_especializada/encaminhamentos_aps_especializada.yml
+++ b/models/encaminhamentos_aps/aps_especializada/encaminhamentos_aps_especializada.yml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2022 Impulso Gov <contato@impulsogov.org>
+#
+# SPDX-License-Identifier: MIT
+
+
+version: 2
+
+models:
+  - name: encaminhamentos_aps_especializada
+    description: >
+      Quantidade de atendimentos individuais em saúde mental realizadas por equipes 
+      da Atenção Primária em Saúde por município e por mês, e quantidade desses 
+      atendimentos que tiveram como desfecho o encaminhamento para serviços  da 
+      rede especializada (não inclui CAPS).
+    config:
+      grants:
+        select: ['saude_mental_analistas', 'saude_mental_integracao'] 
+      alias: encaminhamentos_aps_especializada
+      enabled: true
+      indexes:
+        - columns:
+          - "unidade_geografica_id_sus"
+          - "unidade_geografica_id"
+      materialized: view
+      persist_docs:
+        relation: true
+      tags:
+        - "saude_mental"
+        - "sisab"
+        - "encaminhamentos_aps"
+      unique_key: "id"

--- a/models/encaminhamentos_aps/aps_especializada/encaminhamentos_aps_especializada_resumo_ultimo_mes_horizontal.sql
+++ b/models/encaminhamentos_aps/aps_especializada/encaminhamentos_aps_especializada_resumo_ultimo_mes_horizontal.sql
@@ -1,0 +1,73 @@
+{#
+SPDX-FileCopyrightText: 2022 ImpulsoGov <contato@impulsogov.org>
+ 
+SPDX-License-Identifier: MIT
+#}
+
+
+WITH
+encaminhamentos_aps_especializada AS (
+    SELECT * FROM {{ ref('encaminhamentos_aps_especializada') }}
+),
+relacao_aps_especializada AS (
+SELECT
+    DISTINCT ON (
+        unidade_geografica_id,
+        unidade_geografica_id_sus,
+        conduta
+    )
+    *
+FROM saude_mental.encaminhamentos_aps_especializada
+ORDER BY 
+    unidade_geografica_id,
+    unidade_geografica_id_sus,
+    conduta,
+    competencia DESC
+),
+relacao_aps_especializada_horizontalizado AS (
+    SELECT
+        unidade_geografica_id,
+        unidade_geografica_id_sus,
+        periodo_id,
+        competencia,
+        nome_mes,
+        sum(quantidade_registrada) FILTER (
+            WHERE conduta = 'Encaminhamento para serviço especializado'
+        ) AS encaminhamentos_especializada,
+        sum(quantidade_registrada_anterior) FILTER (
+            WHERE conduta = 'Encaminhamento para serviço especializado'
+        ) AS encaminhamentos_especializada_anterior,
+        sum(quantidade_registrada) FILTER (
+            WHERE conduta = 'Todas'
+        ) AS atendimentos_sm_aps,
+        sum(quantidade_registrada_anterior) FILTER (
+            WHERE conduta = 'Todas'
+        ) AS atendimentos_sm_aps_anterior
+    FROM relacao_aps_especializada
+    GROUP BY 
+        unidade_geografica_id,
+        unidade_geografica_id_sus,
+        periodo_id,
+        competencia,
+        nome_mes
+),
+final AS (
+    SELECT
+        unidade_geografica_id,
+        unidade_geografica_id_sus,
+        periodo_id,
+        competencia,
+        nome_mes,
+        encaminhamentos_especializada,
+        atendimentos_sm_aps,
+        round(
+            100 * encaminhamentos_especializada
+            / nullif(atendimentos_sm_aps, 0),
+            2
+        ) AS perc_encaminhamentos_especializada,
+        (
+            encaminhamentos_especializada - encaminhamentos_especializada_anterior
+        ) AS dif_encaminhamentos_especializada_anterior
+    FROM relacao_aps_especializada_horizontalizado
+)
+SELECT * FROM final

--- a/models/encaminhamentos_aps/aps_especializada/encaminhamentos_aps_especializada_resumo_ultimo_mes_horizontal.yml
+++ b/models/encaminhamentos_aps/aps_especializada/encaminhamentos_aps_especializada_resumo_ultimo_mes_horizontal.yml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2022 Impulso Gov <contato@impulsogov.org>
+#
+# SPDX-License-Identifier: MIT
+
+
+version: 2
+
+models:
+  - name: encaminhamentos_aps_especializada_resumo_ultimo_mes_horizontal
+    description: >
+      Quantidade de atendimentos individuais em saúde mental realizadas 
+      por equipes da Atenção Primária em Saúde por município na última 
+      competência com dados disponíveis, e quantidade desses atendimentos 
+      que tiveram como desfecho o encaminhamento para serviços  da rede 
+      especializada (não inclui CAPS).
+    config:
+      grants:
+        select: ['saude_mental_analistas', 'saude_mental_integracao'] 
+      alias: encaminhamentos_aps_especializada_resumo_ultimo_mes_horizontal
+      enabled: true
+      indexes:
+        - columns:
+          - "id"
+          unique: true
+        - columns:
+          - "unidade_geografica_id_sus"
+          - "unidade_geografica_id"
+      materialized: view
+      persist_docs:
+        relation: true
+      tags:
+        - "saude_mental"
+        - "sisab"
+        - "encaminhamentos_aps"
+      unique_key: "id"

--- a/models/primeiras_competencias_disponiveis/aih_rd_disseminacao_primeira_competencia.yml
+++ b/models/primeiras_competencias_disponiveis/aih_rd_disseminacao_primeira_competencia.yml
@@ -6,7 +6,7 @@
 version: 2
 
 models:
-  - name: aih_rd_dissiminacao_primeira_competencia
+  - name: aih_rd_disseminacao_primeira_competencia
     description: >
       Lista as últimas competências para as quais houve disponibilização dos
       arquivos de disseminação dos Boletins de Produção Ambulatorial

--- a/models/sources/sisab.yml
+++ b/models/sources/sisab.yml
@@ -22,3 +22,9 @@ sources:
           Relatório de produção do Sistema de Informações em Saúde para a Atenção Básica 
           que relaciona os tipos de equipe ao tipo (e ao tamanho) da produção realizada 
           mensalmente em cada município.
+      - name: sisab_producao_conduta_problema_condicao
+        identifier: sisab_producao_municipios_por_conduta_por_problema_condicao_ava
+        description: >
+          Quantidade de atendimentos individuais realizados por equipes da Atenção Primária 
+          à Saúde, por município, mês, categoria de problema/condição avaliada e desfecho 
+          do atendimento.

--- a/models/ultimas_competencias_disponiveis/sisab_producao_conduta_problema_condicao_ultima_competencia.sql
+++ b/models/ultimas_competencias_disponiveis/sisab_producao_conduta_problema_condicao_ultima_competencia.sql
@@ -1,0 +1,39 @@
+{#
+SPDX-FileCopyrightText: 2022 ImpulsoGov <contato@impulsogov.org>
+ 
+SPDX-License-Identifier: MIT
+#}
+
+
+WITH
+sisab_producao_conduta_problema_condicao AS (
+    SELECT * FROM {{ source('sisab', 'sisab_producao_conduta_problema_condicao') }}
+),
+periodos AS (
+    SELECT * FROM {{ source('codigos', 'periodos') }}
+),
+preparacao AS (
+    SELECT 
+        sisab_producao_conduta_problema_condicao.unidade_geografica_id,
+        sisab_producao_conduta_problema_condicao.periodo_id,
+        periodos.data_inicio AS periodo_data_inicio,
+        periodos.id
+    FROM sisab_producao_conduta_problema_condicao
+    LEFT JOIN periodos
+    ON 
+        sisab_producao_conduta_problema_condicao.periodo_id = periodos.id
+    AND periodos.tipo = 'Mensal'
+),
+final AS (
+    SELECT DISTINCT ON (
+            unidade_geografica_id
+        )
+        unidade_geografica_id,
+        periodo_id,
+        periodo_data_inicio
+    FROM preparacao
+    ORDER BY
+        unidade_geografica_id,
+        periodo_data_inicio DESC
+)
+SELECT * FROM final

--- a/models/ultimas_competencias_disponiveis/sisab_producao_conduta_problema_condicao_ultima_competencia.yml
+++ b/models/ultimas_competencias_disponiveis/sisab_producao_conduta_problema_condicao_ultima_competencia.yml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2022 Impulso Gov <contato@impulsogov.org>
+#
+# SPDX-License-Identifier: MIT
+
+
+version: 2
+
+models:
+  - name: sisab_producao_conduta_problema_condicao_ultima_competencia
+    description: >
+      Lista as últimas competências para as quais houve disponibilização dos
+      arquivos do SISAB de quantidade de atendimentos individuais realizados 
+      por equipes da Atenção Primária à Saúde, por município, mês, categoria 
+      de problema/condição avaliada e desfecho.
+    config:
+      grants:
+        select: ['saude_mental_analistas', 'saude_mental_integracao']
+      alias: _sisab_producao_conduta_problema_condicao_ultima_competencia
+      enabled: true
+      indexes:
+        - columns:
+            - "unidade_geografica_id"
+          unique: true
+      materialized: table
+      persist_docs:
+        relation: true
+      tags:
+        - "sisab"
+        - "encaminhamentos"


### PR DESCRIPTION
Mover os indicadores de encaminhamentos da APS para CAPS e da APS para especializada  - atualmente localizados no repositório [ImpulsoGov/bd](https://github.com/ImpulsoGov/bd/blob/main/Scripts/saude_mental/encaminhamentos_aps.sql), para este repositório, e refatorá-los para utilizar as funcionalidades do dbt.

As views criadas substituirão as views materializadas (todas armazenadas no schema saude_mental) abaixo:
`[nome da view materializada a ser substituída no bd]`  -> `[nome da view gerada via dbt]`

**APS <> Especializada**
- [x] `_aps_encaminhamentos_especializada` -> `_encaminhamentos_aps_especializada`
- [x] `aps_encaminhamentos_especializada` -> `encaminhamentos_aps_especializada`
- [x] `aps_encaminhamentos_especializada_resumo_ultimo_mes` -> `encaminhamentos_aps_especializada_resumo_ultimo_mes_horizontal`

**APS <> CAPS**
- [x] `_aps_encaminhamentos_caps` -> `_encaminhamentos_aps_caps`
- [x] `aps_encaminhamentos_caps` -> `encaminhamentos_aps_caps`
- [x] `aps_encaminhamentos_caps_resumo_ultimo_mes` -> `encaminhamentos_aps_caps_resumo_ultimo_mes_horizontal`