### PR TITLE
feat: :sparkles: Adiciona modelos de novos usuários para CAPS

### DIFF
--- a/models/caps/usuarios_novos/_caps_usuarios_novos_perfil.sql
+++ b/models/caps/usuarios_novos/_caps_usuarios_novos_perfil.sql
@@ -1,0 +1,221 @@
+{#
+SPDX-FileCopyrightText: 2022 ImpulsoGov <contato@impulsogov.org>
+ 
+SPDX-License-Identifier: MIT
+#}
+
+
+WITH
+caps_procedimentos AS (
+    SELECT * FROM {{ ref('caps_procedimentos_individualizaveis') }}
+),
+condicoes_saude AS (
+    SELECT 
+        DISTINCT ON (id_cid10)
+        *
+    FROM {{ source("codigos", "condicoes_saude") }}
+    ORDER BY id_cid10
+),
+usuarios AS (
+	SELECT 
+        DISTINCT ON (
+	       estabelecimento_id_scnes,
+	       usuario_id_cns_criptografado
+	    )
+        unidade_geografica_id,
+        unidade_geografica_id_sus,
+        periodo_id,
+        periodo_data_inicio,
+        estabelecimento_id_scnes,        
+        estabelecimento_tipo_id_sigtap,        
+        usuario_id_cns_criptografado,        
+        usuario_nascimento_data,
+        usuario_sexo_id_sigtap,
+        condicao_principal_id_cid10,
+        condicoes_saude.grupo_descricao_curta_cid10 AS usuario_condicao_saude,
+        usuario_raca_cor_id_siasus,
+        usuario_situacao_rua,
+        usuario_abuso_substancias,
+        carater_atendimento_id_siasus,
+        procedimento_id_sigtap,
+        quantidade_apresentada,
+        atualizacao_data
+	FROM caps_procedimentos    
+    LEFT JOIN condicoes_saude
+    ON caps_procedimentos.condicao_principal_id_cid10 = condicoes_saude.id_cid10
+	WHERE 
+        quantidade_apresentada > 0 AND 
+        procedimento_id_sigtap NOT IN (
+            '0301080232',  -- ACOLHIMENTO INICIAL POR CAPS
+            '0301040079'  -- ESCUTA INICIAL/ORIENTAÇÃO (AC DEMANDA ESPONT)
+            ) AND
+        estabelecimento_tipo_id_sigtap = '70' -- CAPS
+	ORDER BY 
+       estabelecimento_id_scnes,
+       usuario_id_cns_criptografado,
+       periodo_data_inicio asc
+),
+{{ classificar_faixa_etaria(
+    relacao="usuarios",
+    coluna_nascimento_data="usuario_nascimento_data",
+    coluna_data_referencia="periodo_data_inicio",
+    idade_tipo="Anos",
+    faixa_etaria_agrupamento="10 em 10 anos",
+    colunas_faixa_etaria=["id", "descricao", "ordem"],
+    cte_resultado="usuarios_com_idade"
+) }},
+_usuarios_novos AS (
+    SELECT 
+        unidade_geografica_id,
+        unidade_geografica_id_sus,
+        periodo_id,
+        estabelecimento_id_scnes,
+        periodo_data_inicio,
+        usuario_condicao_saude,
+        usuario_sexo_id_sigtap,
+        usuario_abuso_substancias,
+        usuario_situacao_rua,
+        usuario_raca_cor_id_siasus,
+        faixa_etaria_id AS usuario_faixa_etaria_id,
+        faixa_etaria_descricao AS usuario_faixa_etaria,
+        faixa_etaria_ordem AS usuario_faixa_etaria_ordem,
+        extract(YEAR FROM age(periodo_data_inicio, usuario_nascimento_data))
+            AS usuario_idade,
+        count(DISTINCT usuario_id_cns_criptografado) AS usuarios_novos
+    FROM usuarios_com_idade
+    GROUP BY 
+        unidade_geografica_id,
+        unidade_geografica_id_sus,
+        periodo_id,
+        periodo_data_inicio,
+        estabelecimento_id_scnes,
+        usuario_condicao_saude,
+        usuario_sexo_id_sigtap,
+        usuario_abuso_substancias,
+        usuario_situacao_rua,
+        usuario_raca_cor_id_siasus,
+        usuario_faixa_etaria_id,
+        usuario_faixa_etaria,
+        usuario_faixa_etaria_ordem,
+        usuario_idade
+),
+{{ juntar_periodos_consecutivos(
+    relacao="_usuarios_novos",
+    agrupar_por=[
+        "unidade_geografica_id", 
+        "unidade_geografica_id_sus", 
+        "estabelecimento_id_scnes", 
+        "usuario_condicao_saude", 
+        "usuario_sexo_id_sigtap", 
+        "usuario_abuso_substancias", 
+        "usuario_situacao_rua", 
+        "usuario_raca_cor_id_siasus", 
+        "usuario_faixa_etaria_id", 
+        "usuario_faixa_etaria", 
+        "usuario_faixa_etaria_ordem", 
+        "usuario_idade",
+    ],
+    colunas_valores=[
+        "usuarios_novos"
+    ],
+    periodo_tipo="Mensal",
+    coluna_periodo="periodo_id",    
+    colunas_adicionais_periodo=[
+        "periodo_data_inicio"
+        ],
+    cte_resultado="com_periodo_anterior"
+) }},
+{{ ultimas_competencias(
+    relacao="com_periodo_anterior",
+    fontes=["raas_psicossocial_disseminacao"],
+    meses_antes_ultima_competencia=(0, none),
+    cte_resultado="ate_ultima_competencia"
+) }},
+intermediaria AS (
+    SELECT
+        unidade_geografica_id,
+        unidade_geografica_id_sus,
+        periodo_id,
+        periodo_data_inicio,        
+        estabelecimento_id_scnes,
+        usuario_condicao_saude,
+        usuario_sexo_id_sigtap,
+        saude_mental.classificar_binarios(
+            usuario_situacao_rua
+        ) AS usuario_situacao_rua,
+        saude_mental.classificar_binarios(
+            usuario_abuso_substancias
+        ) AS usuario_abuso_substancias,
+        usuario_raca_cor_id_siasus,
+        usuario_faixa_etaria_id,
+        usuario_faixa_etaria,
+        usuario_faixa_etaria_ordem,
+        usuario_idade,
+        usuarios_novos,
+        usuarios_novos_anterior,
+        now() AS atualizacao_data   
+    FROM ate_ultima_competencia
+),
+{{ classificar_caps_linha(
+    relacao="intermediaria",
+    coluna_linha_perfil="estabelecimento_linha_perfil",
+    coluna_linha_idade="estabelecimento_linha_idade",
+    coluna_estabelecimento_id="estabelecimento_id_scnes",
+    todos_estabelecimentos_id=none,
+    todas_linhas_valor=none,
+    cte_resultado="por_estabelecimento_com_linhas_cuidado"
+) }},
+{{ calcular_subtotais(
+    relacao="por_estabelecimento_com_linhas_cuidado",
+    agrupar_por=[
+        "unidade_geografica_id",
+        "unidade_geografica_id_sus",
+        "periodo_id",
+        "periodo_data_inicio",        
+        "usuario_faixa_etaria_id",
+        "usuario_faixa_etaria",
+        "usuario_faixa_etaria_ordem",
+        "usuario_sexo_id_sigtap",
+        "usuario_condicao_saude",
+        "usuario_raca_cor_id_siasus",
+        "usuario_situacao_rua",
+        "usuario_abuso_substancias",
+        "usuario_idade"
+    ],
+    colunas_a_totalizar=[
+		"estabelecimento_linha_perfil",
+    	"estabelecimento_linha_idade",
+		"estabelecimento_id_scnes"
+    ],
+    nomes_categorias_com_totais=["Todos", "Todos", "0000000"],
+    agregacoes_valores={
+        "usuarios_novos": "sum",
+        "usuarios_novos_anterior": "sum",
+        "atualizacao_data": "max"
+    },
+    manter_original=true,
+    cte_resultado="usuario_perfil_incluindo_totais"
+) }},
+final AS (
+    SELECT
+        {{ dbt_utils.surrogate_key([
+            "unidade_geografica_id",
+		    "estabelecimento_linha_perfil",
+    	    "estabelecimento_linha_idade",
+            "estabelecimento_id_scnes",
+            "periodo_id",
+            "usuario_faixa_etaria_id",
+            "usuario_sexo_id_sigtap",
+            "usuario_condicao_saude",
+            "usuario_raca_cor_id_siasus",
+            "usuario_situacao_rua",
+            "usuario_abuso_substancias"
+        ]) }} AS id,
+        *,        
+        (
+            coalesce(usuario_perfil_incluindo_totais.usuarios_novos, 0)
+            - coalesce(usuario_perfil_incluindo_totais.usuarios_novos_anterior, 0)
+        ) AS dif_usuarios_novos_anterior
+    FROM usuario_perfil_incluindo_totais
+)
+SELECT * FROM final

--- a/models/caps/usuarios_novos/_caps_usuarios_novos_perfil.yml
+++ b/models/caps/usuarios_novos/_caps_usuarios_novos_perfil.yml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2022 Impulso Gov <contato@impulsogov.org>
+#
+# SPDX-License-Identifier: MIT
+
+
+version: 2
+
+models:
+  - name: _caps_usuarios_novos_perfil
+    description: >
+      **Modelo para uso interno no dbt**. Ver modelo [`caps_usuarios_novos_perfil`](https://impulsogov.github.io/saude-mental-indicadores/#!/model/model.impulso_saude_mental.caps_usuarios_novos_perfil) para a versão final. 
+      Perfil dos usuários que realizaram o primeiro procedimento em CAPS na competência em questão.
+    config:
+      grants:
+        select: ['saude_mental_analistas', 'saude_mental_integracao']
+      alias: _caps_usuarios_novos_perfil
+      enabled: true
+      indexes:
+        - columns:
+          - "unidade_geografica_id_sus"
+        - columns:
+          - "periodo_data_inicio"
+          - "periodo_id"
+        - columns:
+          - "unidade_geografica_id_sus"
+          - "estabelecimento_id_scnes"
+          - "periodo_id"
+        - columns:
+          - "unidade_geografica_id_sus"
+          - "usuario_condicao_saude"
+      materialized: table
+      persist_docs:
+        relation: true
+      tags:
+        - "saude_mental"
+        - "caps"
+        - "raas"
+        - "usuarios_novos"

--- a/models/caps/usuarios_novos/caps_usuarios_novos_perfil.sql
+++ b/models/caps/usuarios_novos/caps_usuarios_novos_perfil.sql
@@ -1,0 +1,14 @@
+{#
+SPDX-FileCopyrightText: 2022 ImpulsoGov <contato@impulsogov.org>
+ 
+SPDX-License-Identifier: MIT
+#}
+
+-- depends_on: {{ ref('_caps_usuarios_novos_perfil') }}
+
+WITH
+{{ preparar_uso_externo(
+	relacao="_caps_usuarios_novos_perfil",
+	cte_resultado="final"
+) }}
+SELECT * FROM final

--- a/models/caps/usuarios_novos/caps_usuarios_novos_perfil.yml
+++ b/models/caps/usuarios_novos/caps_usuarios_novos_perfil.yml
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2022 Impulso Gov <contato@impulsogov.org>
+#
+# SPDX-License-Identifier: MIT
+
+
+version: 2
+
+models:
+  - name: caps_usuarios_novos_perfil
+    description: >
+      Perfil dos usuários que realizaram o primeiro procedimento em CAPS na competência em questão.
+    config:
+      grants:
+        select: ['saude_mental_analistas', 'saude_mental_integracao']
+      alias: caps_usuarios_novos_perfil
+      enabled: true
+      indexes:
+        - columns:
+          - "unidade_geografica_id_sus"
+          - "estabelecimento"
+        - columns:
+          - "unidade_geografica_id_sus"
+          - "estabelecimento_linha_idade"
+        - columns:
+          - "unidade_geografica_id_sus"
+          - "estabelecimento_linha_perfil"
+        - columns:
+          - "unidade_geografica_id_sus"
+          - "periodo"
+          - "periodo_ordem"
+        - columns:
+          - "unidade_geografica_id_sus"
+          - "usuario_abuso_substancias"
+        - columns:
+          - "unidade_geografica_id_sus"
+          - "usuario_situacao_rua"
+        - columns:
+          - "unidade_geografica_id_sus"
+          - "usuario_condicao_saude"
+        - columns:
+          - "unidade_geografica_id_sus"
+          - "usuario_faixa_etaria"
+        - columns:
+          - "unidade_geografica_id_sus"
+          - "raca_cor"
+        - columns:
+          - "unidade_geografica_id_sus"
+          - "sexo"
+      materialized: table
+      persist_docs:
+        relation: true
+      tags:
+        - "saude_mental"
+        - "caps"
+        - "raas"
+        - "usuarios_novos"

--- a/models/caps/usuarios_novos/caps_usuarios_novos_resumo.sql
+++ b/models/caps/usuarios_novos/caps_usuarios_novos_resumo.sql
@@ -1,0 +1,72 @@
+{#
+SPDX-FileCopyrightText: 2022 ImpulsoGov <contato@impulsogov.org>
+ 
+SPDX-License-Identifier: MIT
+#}
+
+
+WITH
+usuarios_novos AS (
+    SELECT * FROM {{ ref('caps_usuarios_novos_perfil') }}
+),
+usuarios_ativos AS (
+    SELECT * FROM {{ ref('caps_usuarios_ativos_por_estabelecimento_resumo') }}
+),
+resumo_usuarios_novos AS (
+    SELECT
+        unidade_geografica_id,
+        unidade_geografica_id_sus,
+        periodo_id,
+        periodo,
+        periodo_ordem,
+        nome_mes,
+        competencia,
+        estabelecimento_linha_perfil,
+        estabelecimento_linha_idade,
+        estabelecimento,
+        sum(usuarios_novos) AS usuarios_novos,
+        sum(usuarios_novos_anterior) AS usuarios_novos_anterior,
+        sum(dif_usuarios_novos_anterior) AS dif_usuarios_novos_anterior
+    FROM usuarios_novos
+    GROUP BY 
+        unidade_geografica_id,
+        unidade_geografica_id_sus,
+        periodo_id,
+        periodo,
+        periodo_ordem,
+        nome_mes,
+        competencia,
+        estabelecimento_linha_perfil,
+        estabelecimento_linha_idade,
+        estabelecimento
+),
+final AS (
+    SELECT 
+        usuarios_ativos.unidade_geografica_id,
+        usuarios_ativos.unidade_geografica_id_sus,
+        usuarios_ativos.periodo_id,        
+        usuarios_ativos.competencia,
+        usuarios_ativos.estabelecimento_linha_perfil,
+        usuarios_ativos.estabelecimento_linha_idade,
+        coalesce(usuarios_novos, 0) AS usuarios_novos,
+        coalesce(usuarios_novos_anterior, 0) AS usuarios_novos_anterior,
+        coalesce(dif_usuarios_novos_anterior, 0) AS dif_usuarios_novos_anterior,
+        usuarios_ativos.estabelecimento,
+        usuarios_ativos.periodo,
+        usuarios_ativos.nome_mes,
+        usuarios_ativos.periodo_ordem
+    FROM resumo_usuarios_novos
+    -- Junta com usuários ativos para garantir que todos os CAPS com usuários ativos
+    -- apareçam na consulta final, mesmo que não haja usuários novos no mês nem no
+    -- anterior
+    RIGHT JOIN
+        usuarios_ativos
+    USING (
+        unidade_geografica_id,
+        periodo_id,
+        estabelecimento,
+        estabelecimento_linha_perfil,
+        estabelecimento_linha_idade
+    )
+)
+SELECT * FROM final

--- a/models/caps/usuarios_novos/caps_usuarios_novos_resumo.yml
+++ b/models/caps/usuarios_novos/caps_usuarios_novos_resumo.yml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2022 Impulso Gov <contato@impulsogov.org>
+#
+# SPDX-License-Identifier: MIT
+
+
+version: 2
+
+models:
+  - name: caps_usuarios_novos_resumo
+    description: >
+      Quantidade resumida por estabelecimento dos novos usuários que começaram a frequentar os CAPS.
+    config:
+      grants:
+        select: ['saude_mental_analistas', 'saude_mental_integracao']
+      alias: caps_usuarios_novos_resumo
+      enabled: true
+      indexes:
+        - columns:
+          - "unidade_geografica_id_sus"
+          - "estabelecimento"
+        - columns:
+          - "unidade_geografica_id_sus"
+          - "estabelecimento_linha_idade"
+        - columns:
+          - "unidade_geografica_id_sus"
+          - "estabelecimento_linha_perfil"
+        - columns:
+          - "unidade_geografica_id_sus"
+          - "periodo"
+          - "periodo_ordem"
+      materialized: table
+      persist_docs:
+        relation: true
+      tags:
+        - "saude_mental"
+        - "caps"
+        - "raas"
+        - "usuarios_novos"


### PR DESCRIPTION
Move o indicador de novos usuários - atualmente localizado no repositório [ImpulsoGov/bd](https://github.com/ImpulsoGov/bd/blob/main/Scripts/saude_mental/usuarios_novos.sql), para este repositório, e refatora para utilizar as funcionalidades do dbt.

As tabelas criadas substituirão as views materializadas (todas armazenadas no schema saude_mental) abaixo:
[nome da view materializada a ser substituída no bd] -> [nome da tabela gerada via dbt]

**Novos usuários**
- [x] `_usuarios_novos` -> `_caps_usuarios_novos_perfil`
- [x] `usuarios_novos` -> `caps_usuarios_novos_perfil`
- [x] `usuarios_novos_resumo_ultimo_mes` -> `caps_usuarios_novos_resumo`