### PR TITLE
Limita competências das tabelas de indicadores para os últimos 72 meses

### DIFF
--- a/analyses/_caps_usuarios_ativos_perfil_cidcompleto_barbalha.sql
+++ b/analyses/_caps_usuarios_ativos_perfil_cidcompleto_barbalha.sql
@@ -1,0 +1,164 @@
+{#
+SPDX-FileCopyrightText: 2022 ImpulsoGov <contato@impulsogov.org>
+
+SPDX-License-Identifier: MIT
+#}
+
+
+WITH
+usuarios_ativos AS (
+    SELECT *
+    FROM {{ ref("caps_usuarios_ativos") }}
+	WHERE usuario_primeiro_procedimento_periodo_data_inicio IS NOT NULL
+    AND unidade_geografica_id_sus = '230190'
+),
+condicoes_saude AS (
+    SELECT 
+        DISTINCT ON (id_cid10)
+        *
+    FROM {{ source("codigos", "condicoes_saude") }}
+    ORDER BY id_cid10
+),
+por_estabelecimentos AS (
+    SELECT
+        unidade_geografica_id,
+        unidade_geografica_id_sus,
+        periodo_id,
+        periodo_data_inicio,
+        estabelecimento_id_scnes,
+        usuario_tempo_servico_id,
+        usuario_tempo_servico_descricao,
+        usuario_tempo_servico_ordem,
+        usuario_faixa_etaria_id,
+        usuario_faixa_etaria_descricao,
+        usuario_faixa_etaria_ordem,
+        usuario_sexo_id_sigtap,
+        condicao_principal_id_cid10, -- condicoes_saude.grupo_id_cid10,
+        condicoes_saude.descricao_longa_cid10 AS usuario_condicao_saude,
+        usuario_raca_cor_id_siasus,
+        usuario_situacao_rua,
+        usuario_abuso_substancias,
+        count (DISTINCT usuario_id_cns_criptografado) FILTER (
+            WHERE ativo_mes
+        ) AS ativos_mes,
+        count (DISTINCT usuario_id_cns_criptografado) FILTER (
+            WHERE ativo_3meses
+        ) AS ativos_3meses,
+        count (DISTINCT usuario_id_cns_criptografado) FILTER (
+            WHERE tornandose_inativo
+        ) AS tornandose_inativos,
+        max(atualizacao_data) AS atualizacao_data
+    FROM usuarios_ativos
+    LEFT JOIN condicoes_saude
+    ON usuarios_ativos.condicao_principal_id_cid10 = condicoes_saude.id_cid10
+    GROUP BY
+        unidade_geografica_id,
+        unidade_geografica_id_sus,
+        periodo_id,
+        periodo_data_inicio,
+        estabelecimento_id_scnes,
+        usuario_tempo_servico_id,
+        usuario_tempo_servico_descricao,
+        usuario_tempo_servico_ordem,
+        usuario_faixa_etaria_id,
+        usuario_faixa_etaria_descricao,
+        usuario_faixa_etaria_ordem,
+        usuario_sexo_id_sigtap,
+        condicao_principal_id_cid10, -- condicoes_saude.grupo_id_cid10,
+        condicoes_saude.descricao_longa_cid10,
+        usuario_raca_cor_id_siasus,
+        usuario_situacao_rua,
+        usuario_abuso_substancias
+),
+{{ classificar_caps_linha(
+    relacao="por_estabelecimentos",
+    coluna_linha_perfil="estabelecimento_linha_perfil",
+    coluna_linha_idade="estabelecimento_linha_idade",
+    coluna_estabelecimento_id="estabelecimento_id_scnes",
+    todos_estabelecimentos_id=none,
+    todas_linhas_valor=none,
+    cte_resultado="por_estabelecimento_com_linhas_cuidado"
+) }},
+{{ calcular_subtotais(
+    relacao="por_estabelecimento_com_linhas_cuidado",
+    agrupar_por=[
+        "unidade_geografica_id",
+        "unidade_geografica_id_sus",
+        "periodo_id",
+        "periodo_data_inicio",
+        "usuario_tempo_servico_id",
+        "usuario_tempo_servico_descricao",
+        "usuario_tempo_servico_ordem",
+        "usuario_faixa_etaria_id",
+        "usuario_faixa_etaria_descricao",
+        "usuario_faixa_etaria_ordem",
+        "usuario_sexo_id_sigtap",
+        "condicao_principal_id_cid10",
+        "usuario_condicao_saude",
+        "usuario_raca_cor_id_siasus",
+        "usuario_situacao_rua",
+        "usuario_abuso_substancias"
+    ],
+    colunas_a_totalizar=[
+		"estabelecimento_linha_perfil",
+    	"estabelecimento_linha_idade",
+		"estabelecimento_id_scnes"
+    ],
+    nomes_categorias_com_totais=["Todos", "Todos", "0000000"],
+    agregacoes_valores={
+        "ativos_mes": "sum",
+        "ativos_3meses": "sum",
+        "tornandose_inativos": "sum",
+        "atualizacao_data": "max"
+    },
+    manter_original=true,
+    cte_resultado="usuario_perfil_incluindo_totais"
+) }},
+{{  remover_subtotais(
+    relacao="usuario_perfil_incluindo_totais",
+    cte_resultado="com_combinacoes_sem_subtotais"
+) }},
+final AS (
+    SELECT
+        {{ dbt_utils.surrogate_key([
+            "unidade_geografica_id",
+		    "estabelecimento_linha_perfil",
+    	    "estabelecimento_linha_idade",
+            "estabelecimento_id_scnes",
+            "periodo_id",
+            "usuario_tempo_servico_id",
+            "usuario_faixa_etaria_id",
+            "usuario_sexo_id_sigtap",
+            "condicao_principal_id_cid10",
+            "usuario_raca_cor_id_siasus",
+            "usuario_situacao_rua",
+            "usuario_abuso_substancias"
+        ]) }} AS id,
+        unidade_geografica_id,
+        unidade_geografica_id_sus,
+        periodo_id,
+        periodo_data_inicio,
+		estabelecimento_linha_perfil,
+		estabelecimento_linha_idade,
+        estabelecimento_id_scnes,
+        usuario_tempo_servico_descricao AS usuario_tempo_servico,
+        usuario_tempo_servico_ordem,
+        usuario_faixa_etaria_descricao AS usuario_faixa_etaria,
+        usuario_faixa_etaria_ordem,
+        usuario_sexo_id_sigtap,
+        usuario_condicao_saude,
+        usuario_raca_cor_id_siasus,
+        saude_mental.classificar_binarios(
+            usuario_situacao_rua
+        ) AS usuario_situacao_rua,
+        saude_mental.classificar_binarios(
+            usuario_abuso_substancias
+        ) AS usuario_abuso_substancias,
+        ativos_mes,
+        ativos_3meses,
+        tornandose_inativos,
+        now() AS atualizacao_data
+    FROM com_combinacoes_sem_subtotais
+)
+
+SELECT * FROM final

--- a/analyses/_caps_usuarios_ativos_perfil_cidcompleto_barbalha.yml
+++ b/analyses/_caps_usuarios_ativos_perfil_cidcompleto_barbalha.yml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2022 Impulso Gov <contato@impulsogov.org>
+#
+# SPDX-License-Identifier: MIT
+
+
+version: 2
+
+models:
+  - name: _caps_usuarios_ativos_perfil_cidcompleto_barbalha
+    description: >
+      Modelo para uso interno, demanda de usuária do painel.
+    config:
+      grants:
+        select: ['saude_mental_analistas', 'saude_mental_integracao']
+      alias: _caps_usuarios_ativos_perfil_cidcompleto_barbalha
+      enabled: true
+      materialized: view
+      persist_docs:
+        relation: true
+      tags:
+        - "saude_mental"
+        - "caps"
+        - "bpa_i"
+        - "raas"
+        - "usuarios_ativos"

--- a/analyses/caps_usuarios_ativos_perfil_cidcompleto_barbalha.sql
+++ b/analyses/caps_usuarios_ativos_perfil_cidcompleto_barbalha.sql
@@ -1,0 +1,13 @@
+{#
+SPDX-FileCopyrightText: 2022 ImpulsoGov <contato@impulsogov.org>
+
+SPDX-License-Identifier: MIT
+#}
+
+
+WITH
+{{ preparar_uso_externo(
+	relacao="_caps_usuarios_ativos_perfil_cidcompleto_barbalha",
+	cte_resultado="final"
+) }}
+SELECT * FROM final

--- a/analyses/caps_usuarios_ativos_perfil_cidcompleto_barbalha.yml
+++ b/analyses/caps_usuarios_ativos_perfil_cidcompleto_barbalha.yml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2022 Impulso Gov <contato@impulsogov.org>
+#
+# SPDX-License-Identifier: MIT
+
+
+version: 2
+
+models:
+  - name: caps_usuarios_ativos_perfil_cidcompleto_barbalha
+    description: >
+      Modelo para uso interno, demanda de usuária do painel.
+    config:
+      grants:
+        select: ['saude_mental_analistas', 'saude_mental_integracao']
+      alias: caps_usuarios_ativos_perfil_cidcompleto_barbalha
+      enabled: true
+      materialized: table
+      persist_docs:
+        relation: true
+      tags:
+        - "saude_mental"
+        - "caps"
+        - "bpa_i"
+        - "raas"
+        - "usuarios_ativos"

--- a/macros/selecionar_competencias/limitar_quantidade_meses.sql
+++ b/macros/selecionar_competencias/limitar_quantidade_meses.sql
@@ -15,19 +15,46 @@ SPDX-License-Identifier: MIT
     )
 -%}
 
-ultimos_meses_municipio AS (
-    SELECT
-        {{ coluna_municipio_id }},
-        MAX({{ coluna_data }}) as max_data
-    FROM {{ relacao }}
-    GROUP BY {{ coluna_municipio_id }}
-),
+{% set necessario_tabela_periodos = coluna_data == "periodo_id" %}
+
+{% if necessario_tabela_periodos %}
+    ultimos_meses_municipio AS (
+        SELECT 
+            umm_sem_periodo_id.*,
+            periodos.id as periodo_id
+        FROM (
+            SELECT
+                {{ coluna_municipio_id }},
+                MAX(periodos.data_inicio) as max_data
+            FROM {{ relacao }} t
+            LEFT JOIN {{ source("codigos", "periodos") }} periodos ON t.periodo_id = periodos.id
+            GROUP BY {{ coluna_municipio_id }}
+        ) umm_sem_periodo_id
+        LEFT JOIN {{ source("codigos", "periodos") }} periodos ON umm_sem_periodo_id.max_data = periodos.data_inicio
+        ),
+{% else %}
+    ultimos_meses_municipio AS (
+        SELECT
+            {{ coluna_municipio_id }},
+            MAX({{ coluna_data }}) as max_data
+        FROM {{ relacao }} t
+        LEFT JOIN {{ source("codigos", "periodos") }} periodos ON t.periodo_id = periodos.id
+        GROUP BY {{ coluna_municipio_id }}
+    ),
+{% endif %}
+
 {{ cte_resultado }} AS (
     SELECT 
         t.*
     FROM {{ relacao }} t
     JOIN ultimos_meses_municipio ON t.{{ coluna_municipio_id }} = ultimos_meses_municipio.{{ coluna_municipio_id }}
-    WHERE t.{{ coluna_data }} >= (ultimos_meses_municipio.max_data - INTERVAL '{{ quantidade_meses_a_limitar }} months'::interval) 
+    {% if necessario_tabela_periodos %}
+        LEFT JOIN {{ source("codigos", "periodos") }} periodos ON t.periodo_id = periodos.id
+        WHERE periodos.data_inicio >= (ultimos_meses_municipio.max_data - INTERVAL '{{ quantidade_meses_a_limitar }} months'::interval)     
+    {% else %}
+        WHERE t.{{ coluna_data }} >= (ultimos_meses_municipio.max_data - INTERVAL '{{ quantidade_meses_a_limitar }} months'::interval) 
+    {% endif %}    
 )
 
 {% endmacro %}
+

--- a/macros/selecionar_competencias/limitar_quantidade_meses.sql
+++ b/macros/selecionar_competencias/limitar_quantidade_meses.sql
@@ -1,0 +1,33 @@
+{#
+SPDX-FileCopyrightText: 2022 ImpulsoGov <contato@impulsogov.org>
+
+SPDX-License-Identifier: MIT
+#}
+
+
+{%- macro 
+    limitar_quantidade_meses(
+        relacao, 
+        coluna_data="realizacao_periodo_data_inicio", 
+        coluna_municipio_id="unidade_geografica_id_sus", 
+        quantidade_meses_a_limitar=72,
+        cte_resultado="com_meses_limitados"
+    )
+-%}
+
+ultimos_meses_municipio AS (
+    SELECT
+        {{ coluna_municipio_id }},
+        MAX({{ coluna_data }}) as max_data
+    FROM {{ relacao }}
+    GROUP BY {{ coluna_municipio_id }}
+),
+{{ cte_resultado }} AS (
+    SELECT 
+        t.*
+    FROM {{ relacao }} t
+    JOIN ultimos_meses_municipio ON t.{{ coluna_municipio_id }} = ultimos_meses_municipio.{{ coluna_municipio_id }}
+    WHERE t.{{ coluna_data }} >= (ultimos_meses_municipio.max_data - INTERVAL '{{ quantidade_meses_a_limitar }} months'::interval) 
+)
+
+{% endmacro %}

--- a/macros/selecionar_competencias/limitar_quantidade_meses.yml
+++ b/macros/selecionar_competencias/limitar_quantidade_meses.yml
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2022 Impulso Gov <contato@impulsogov.org>
+#
+# SPDX-License-Identifier: MIT
+
+
+version: 2
+
+macros:
+  - name: limitar_quantidade_meses
+    description: >
+      Macro para selecionar os últimos N meses (por padrão, 72 meses) por município
+      com relação ao último período para o qual houve o carregamento de dados dos 
+      documentos de origem via DataSUS.
+    docs:
+      show: true
+    arguments:
+      - name: relacao
+        type: Relation | str
+        description: >
+          Objeto [Relation][] ou nome de uma
+          [*Common Table Expression* (CTE)][CTE] cujas competências se deseja
+          filtrar.
+
+          [Relation]: https://docs.getdbt.com/reference/dbt-classes#relation
+          [CTE]: https://pt.wikipedia.org/wiki/Common_table_expression      
+      - name: coluna_data
+        type: str
+        description: >
+          Nome da coluna com a data de referência que será utilizada para a 
+          contagem de meses a limitar a partir da data máxima, por município,
+          presente nessa coluna. Por padrão, assume o valor
+          `realizacao_periodo_data_inicio`, referente a data de realização do 
+          procedimento na tabela fonte.
+      - name: coluna_municipio_id
+        type: str
+        description: >
+          Nome da coluna que contém um identificador único do município
+          de saúde, que deve estar presente também na tabela
+          [`listas_de_codigos.unidades_geograficas`](https://impulsogov.github.io/saude-mental-indicadores/#!/source/source.impulso_saude_mental.codigos.unidades_geograficas)
+          . Por padrão, assume o valor `unidade_geografica_id_sus`.
+      - name: quantidade_meses_a_limitar
+        type: int
+        description: >
+          Número inteiro referente a quantidade de meses que devem ser mantidos
+          no resultado final, considerando a contagem decrescente a partir do último
+          mês registrado. 
+      - name: cte_resultado
+        type: str
+        description: >
+          Nome a ser dado à [CTE][] que contém os resultados, para ser
+          referenciada em passos posteriores da definição de uma consulta.
+          [CTE]: https://pt.wikipedia.org/wiki/Common_table_expression

--- a/macros/utilidades/selecionar_municipios_ativos.sql
+++ b/macros/utilidades/selecionar_municipios_ativos.sql
@@ -1,0 +1,27 @@
+{#
+SPDX-FileCopyrightText: 2022 ImpulsoGov <contato@impulsogov.org>
+
+SPDX-License-Identifier: MIT
+#}
+
+
+{%- macro 
+    selecionar_municipios_ativos(
+        relacao, 
+        coluna_municipio_id="unidade_geografica_id_sus", 
+        cte_resultado="municipios_selecionados"
+    )
+-%}
+
+municipios_ativos AS (
+	SELECT * FROM {{ source("utilidades", "municipios_painel_sm") }}
+    WHERE status_ativo = TRUE
+),
+{{ cte_resultado }} AS (
+    SELECT 
+        tabela.*
+    FROM {{ relacao }} tabela
+    INNER JOIN municipios_ativos 
+    ON tabela.{{ coluna_municipio_id }} = municipios_ativos.id_sus
+)
+{% endmacro %}

--- a/macros/utilidades/selecionar_municipios_ativos.sql
+++ b/macros/utilidades/selecionar_municipios_ativos.sql
@@ -13,6 +13,8 @@ SPDX-License-Identifier: MIT
     )
 -%}
 
+{% set usar_municipio_id = coluna_municipio_id == "unidade_geografica_id" %}
+
 municipios_ativos AS (
 	SELECT * FROM {{ source("utilidades", "municipios_painel_sm") }}
     WHERE status_ativo = TRUE
@@ -22,6 +24,12 @@ municipios_ativos AS (
         tabela.*
     FROM {{ relacao }} tabela
     INNER JOIN municipios_ativos 
-    ON tabela.{{ coluna_municipio_id }} = municipios_ativos.id_sus
+
+    {% if usar_municipio_id %}
+        ON tabela.{{ coluna_municipio_id }} = municipios_ativos.id_mun
+    {% else %}
+        ON tabela.{{ coluna_municipio_id }} = municipios_ativos.id_sus
+    {% endif %}  
 )
+
 {% endmacro %}

--- a/macros/utilidades/selecionar_municipios_ativos.yml
+++ b/macros/utilidades/selecionar_municipios_ativos.yml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2022 Impulso Gov <contato@impulsogov.org>
+#
+# SPDX-License-Identifier: MIT
+
+
+version: 2
+
+macros:
+  - name: selecionar_municipios_ativos
+    description: >
+      Macro para selecionar os municípios atualmente ativos no painel de 
+      Saúde Mental.
+    docs:
+      show: true
+    arguments:
+      - name: relacao
+        type: Relation | str
+        description: >
+          Objeto [Relation][] ou nome de uma
+          [*Common Table Expression* (CTE)][CTE] cujas competências se deseja
+          filtrar.
+
+          [Relation]: https://docs.getdbt.com/reference/dbt-classes#relation
+          [CTE]: https://pt.wikipedia.org/wiki/Common_table_expression      
+      - name: coluna_municipio_id
+        type: str
+        description: >
+          Nome da coluna que contém um identificador único do município
+          de saúde, que deve estar presente também na tabela
+          [`listas_de_codigos.unidades_geograficas`](https://impulsogov.github.io/saude-mental-indicadores/#!/source/source.impulso_saude_mental.codigos.unidades_geograficas)
+          . Por padrão, assume o valor `unidade_geografica_id_sus`.
+      - name: cte_resultado
+        type: str
+        description: >
+          Nome a ser dado à [CTE][] que contém os resultados, para ser
+          referenciada em passos posteriores da definição de uma consulta.
+          [CTE]: https://pt.wikipedia.org/wiki/Common_table_expression

--- a/models/consultorio_na_rua/_consultorio_na_rua_atendimentos.sql
+++ b/models/consultorio_na_rua/_consultorio_na_rua_atendimentos.sql
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MIT
 
 WITH
 sisab_producao_municipios_por_tipo_equipe_por_tipo_producao AS (
-    SELECT * FROM {{ source('sisab', 'sisab_producao_municipios_por_tipo_equipe_por_tipo_producao') }}
+    SELECT * FROM {{ ref("sisab_por_tipo_equipe_tipo_producao_municipios_selecionados") }} 
 ),
 periodos AS (
     SELECT * FROM {{ source('codigos', 'periodos') }}

--- a/models/consultorio_na_rua/consultorio_na_rua_atendimentos_ultimos_12meses.sql
+++ b/models/consultorio_na_rua/consultorio_na_rua_atendimentos_ultimos_12meses.sql
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MIT
 
 WITH
 sisab_producao_municipios_por_tipo_equipe_por_tipo_producao AS (
-    SELECT * FROM {{ source('sisab', 'sisab_producao_municipios_por_tipo_equipe_por_tipo_producao') }}
+    SELECT * FROM {{ ref("sisab_por_tipo_equipe_tipo_producao_municipios_selecionados") }} 
 ),
 periodos AS (
     SELECT * FROM {{ source('codigos', 'periodos') }}

--- a/models/encaminhamentos_aps/aps_caps/_encaminhamentos_aps_caps.sql
+++ b/models/encaminhamentos_aps/aps_caps/_encaminhamentos_aps_caps.sql
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MIT
 
 WITH
 sisab_producao_por_conduta AS (
-    SELECT * FROM {{ source('sisab', 'sisab_producao_conduta_problema_condicao') }}
+    SELECT * FROM {{ ref("sisab_producao_conduta_problema_condicao_municipios_selecionados") }} 
 ),
 periodos AS (
     SELECT * FROM {{ source('codigos', 'periodos') }}

--- a/models/encaminhamentos_aps/aps_caps/_encaminhamentos_aps_caps.sql
+++ b/models/encaminhamentos_aps/aps_caps/_encaminhamentos_aps_caps.sql
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MIT
 
 WITH
 sisab_producao_por_conduta AS (
-    SELECT * FROM {{ ref("sisab_producao_conduta_problema_condicao_municipios_selecionados") }} 
+    SELECT * FROM {{ ref("sisab_conduta_problema_condicao_municipios_selecionados") }} 
 ),
 periodos AS (
     SELECT * FROM {{ source('codigos', 'periodos') }}

--- a/models/encaminhamentos_aps/aps_especializada/_encaminhamentos_aps_especializada.sql
+++ b/models/encaminhamentos_aps/aps_especializada/_encaminhamentos_aps_especializada.sql
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MIT
 
 WITH
 sisab_producao_por_conduta AS (
-    SELECT * FROM {{ source('sisab', 'sisab_producao_conduta_problema_condicao') }}
+    SELECT * FROM {{ ref("sisab_producao_conduta_problema_condicao_municipios_selecionados") }} 
 ),
 periodos AS (
     SELECT * FROM {{ source('codigos', 'periodos') }}

--- a/models/encaminhamentos_aps/aps_especializada/_encaminhamentos_aps_especializada.sql
+++ b/models/encaminhamentos_aps/aps_especializada/_encaminhamentos_aps_especializada.sql
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MIT
 
 WITH
 sisab_producao_por_conduta AS (
-    SELECT * FROM {{ ref("sisab_producao_conduta_problema_condicao_municipios_selecionados") }} 
+    SELECT * FROM {{ ref("sisab_conduta_problema_condicao_municipios_selecionados") }} 
 ),
 periodos AS (
     SELECT * FROM {{ source('codigos', 'periodos') }}

--- a/models/sources/codigos.yml
+++ b/models/sources/codigos.yml
@@ -94,3 +94,18 @@ sources:
         description: >
           Lista a Tabela de Procedimentos do SUS, contendo a correspondência 
           entre códigos e descrição de Sigtap.
+
+  - name: utilidades
+    schema: saude_mental
+    quoting:
+      database: false
+      schema: false
+      identifier: false
+
+    tables:
+
+      - name: municipios_painel_sm
+        identifier: __municipios_painel_sm
+        description: >
+          Lista de municípios ativos e inativos no painel de saúde mental,
+          contendo ID do banco, ID do SUS, nome do município e status.

--- a/models/sources_apenas_municipios_participantes/aih_rd_disseminacao_municipios_selecionados.sql
+++ b/models/sources_apenas_municipios_participantes/aih_rd_disseminacao_municipios_selecionados.sql
@@ -126,44 +126,18 @@ aih_rd_disseminacao AS (
         -- _nao_documentado_num_proc
         -- _nao_documentado_tot_pt_sp
         -- _nao_documentado_cpf_aut
-    FROM {{ source("sihsus", "aih_rd_disseminacao") }}
-    WHERE unidade_geografica_id_sus IN 
-        (
-            '150140', -- Belém/PA
-            '230190', -- Barbalha/CE
-            '230440', -- Fortaleza/CE (para Impulsolandia)
-            '231290', -- Sobral/CE
-            '261160', -- Recife/PE
-            '280030', -- Aracaju/SE
-            '292740', -- Salvador/BA
-            '315780', -- Santa Luzia/MG
-            '320500', -- Serra/ES
-            '320520', -- Vila Velha/ES  
-            -- '330490', -- São Gonçalo/RJ
-            -- '350950', -- Campinas/SP
-            '351640', -- Franco da Rocha/SP
-            '352590', -- Jundiaí/SP
-            -- '410480', -- Cascavel/PR
-            '410690', -- Curitiba/PR
-            '431440', -- Pelotas/RS
-            '431490', -- Porto Alegre/RS   
-            '520140',  -- Aparecida de Goiânia/GO 
+    FROM {{ source("sihsus", "aih_rd_disseminacao") }}    
+),
 
-        -- MUNICIPIOS BNDES
-            -- '260120', -- Arcoverde/PE
-            -- '210005', -- Açailândia/MA
-            -- '150170', -- Bragança/PA
-            -- '230280', -- Canindé/CE
-            -- '280290', -- Itabaiana/SE
-            '280350', -- Lagarto/SE
-            -- '160030', -- Macapá/AP
-            '280480', -- Nossa Senhora do Socorro/SE
-            -- '230970', -- Pacatuba/CE
-            '231130', -- Quixadá/CE
-            '231140', -- Quixeramobim/CE
-            '150680' -- Santarém/PA
-            -- '261390', -- Serra Talhada/PE
+{{ selecionar_municipios_ativos(
+	relacao="aih_rd_disseminacao",
+	cte_resultado="municipios_selecionados"
+) }},
 
-        )
-)
-SELECT * FROM aih_rd_disseminacao
+{{ limitar_quantidade_meses(
+	relacao="municipios_selecionados",
+    coluna_data="periodo_data_inicio",
+	cte_resultado="final"
+) }}
+
+SELECT * FROM final

--- a/models/sources_apenas_municipios_participantes/bpa_i_disseminacao_municipios_selecionados.sql
+++ b/models/sources_apenas_municipios_participantes/bpa_i_disseminacao_municipios_selecionados.sql
@@ -51,42 +51,16 @@ bpa_i_disseminacao AS (
         criacao_data,
         atualizacao_data 
     FROM {{ source("siasus", "bpa_i_disseminacao") }}
-    WHERE unidade_geografica_id_sus IN 
-        (
-            '150140', -- Belém/PA
-            '230190', -- Barbalha/CE
-            '230440', -- Fortaleza/CE (para Impulsolandia)
-            '231290', -- Sobral/CE
-            '261160', -- Recife/PE
-            '280030', -- Aracaju/SE
-            '292740', -- Salvador/BA
-            '315780', -- Santa Luzia/MG
-            '320500', -- Serra/ES
-            '320520', -- Vila Velha/ES  
-            -- '330490', -- São Gonçalo/RJ
-            -- '350950', -- Campinas/SP
-            '351640', -- Franco da Rocha/SP
-            '352590', -- Jundiaí/SP
-            -- '410480', -- Cascavel/PR
-            '410690', -- Curitiba/PR
-            '431440', -- Pelotas/RS
-            '431490', -- Porto Alegre/RS   
-            '520140',  -- Aparecida de Goiânia/GO 
+), 
 
-        -- MUNICIPIOS BNDES
-            -- '260120', -- Arcoverde/PE
-            -- '210005', -- Açailândia/MA
-            -- '150170', -- Bragança/PA
-            -- '230280', -- Canindé/CE
-            -- '280290', -- Itabaiana/SE
-            '280350', -- Lagarto/SE
-            -- '160030', -- Macapá/AP
-            '280480', -- Nossa Senhora do Socorro/SE
-            -- '230970', -- Pacatuba/CE
-            '231130', -- Quixadá/CE
-            '231140', -- Quixeramobim/CE
-            '150680' -- Santarém/PA
-            -- '261390', -- Serra Talhada/PE         
-        )
-)
-SELECT * FROM bpa_i_disseminacao
+{{ selecionar_municipios_ativos(
+	relacao="bpa_i_disseminacao",
+	cte_resultado="municipios_selecionados"
+) }},
+
+{{ limitar_quantidade_meses(
+	relacao="municipios_selecionados",
+	cte_resultado="final"
+) }}
+
+SELECT * FROM final

--- a/models/sources_apenas_municipios_participantes/procedimentos_disseminacao_municipios_selecionados.sql
+++ b/models/sources_apenas_municipios_participantes/procedimentos_disseminacao_municipios_selecionados.sql
@@ -76,42 +76,16 @@ procedimentos_disseminacao AS (
         criacao_data,
         atualizacao_data
     FROM {{ source("siasus", "procedimentos_disseminacao") }}
-    WHERE unidade_geografica_id_sus IN 
-        (
-            '150140', -- Belém/PA
-            '230190', -- Barbalha/CE
-            '230440', -- Fortaleza/CE (para Impulsolandia)
-            '231290', -- Sobral/CE
-            '261160', -- Recife/PE
-            '280030', -- Aracaju/SE
-            '292740', -- Salvador/BA
-            '315780', -- Santa Luzia/MG
-            '320500', -- Serra/ES
-            '320520', -- Vila Velha/ES  
-            -- '330490', -- São Gonçalo/RJ
-            -- '350950', -- Campinas/SP
-            '351640', -- Franco da Rocha/SP
-            '352590', -- Jundiaí/SP
-            -- '410480', -- Cascavel/PR
-            '410690', -- Curitiba/PR
-            '431440', -- Pelotas/RS
-            '431490', -- Porto Alegre/RS   
-            '520140',  -- Aparecida de Goiânia/GO 
+), 
 
-        -- MUNICIPIOS BNDES
-            -- '260120', -- Arcoverde/PE
-            -- '210005', -- Açailândia/MA
-            -- '150170', -- Bragança/PA
-            -- '230280', -- Canindé/CE
-            -- '280290', -- Itabaiana/SE
-            '280350', -- Lagarto/SE
-            -- '160030', -- Macapá/AP
-            '280480', -- Nossa Senhora do Socorro/SE
-            -- '230970', -- Pacatuba/CE
-            '231130', -- Quixadá/CE
-            '231140', -- Quixeramobim/CE
-            '150680' -- Santarém/PA
-            -- '261390', -- Serra Talhada/PE       
-        )
-)
-SELECT * FROM procedimentos_disseminacao
+{{ selecionar_municipios_ativos(
+	relacao="procedimentos_disseminacao",
+	cte_resultado="municipios_selecionados"
+) }},
+
+{{ limitar_quantidade_meses(
+	relacao="municipios_selecionados",
+	cte_resultado="final"
+) }}
+
+SELECT * FROM final

--- a/models/sources_apenas_municipios_participantes/raas_psicossocial_disseminacao_municipios_selecionados.sql
+++ b/models/sources_apenas_municipios_participantes/raas_psicossocial_disseminacao_municipios_selecionados.sql
@@ -10,46 +10,14 @@ WITH
 raas_psicossocial_disseminacao AS (
 	SELECT * FROM {{ source("siasus", "raas_psicossocial_disseminacao") }}
 ),
-final AS (
-    SELECT 
-        * 
-    FROM raas_psicossocial_disseminacao
-    WHERE unidade_geografica_id_sus IN 
-        (
-            '150140', -- Belém/PA
-            '230190', -- Barbalha/CE
-            '230440', -- Fortaleza/CE (para Impulsolandia)
-            '231290', -- Sobral/CE
-            '261160', -- Recife/PE
-            '280030', -- Aracaju/SE
-            '292740', -- Salvador/BA
-            '315780', -- Santa Luzia/MG
-            '320500', -- Serra/ES
-            '320520', -- Vila Velha/ES  
-            -- '330490', -- São Gonçalo/RJ
-            -- '350950', -- Campinas/SP
-            '351640', -- Franco da Rocha/SP
-            '352590', -- Jundiaí/SP
-            -- '410480', -- Cascavel/PR
-            '410690', -- Curitiba/PR
-            '431440', -- Pelotas/RS
-            '431490', -- Porto Alegre/RS   
-            '520140',  -- Aparecida de Goiânia/GO 
 
-        -- MUNICIPIOS BNDES
-            -- '260120', -- Arcoverde/PE
-            -- '210005', -- Açailândia/MA
-            -- '150170', -- Bragança/PA
-            -- '230280', -- Canindé/CE
-            -- '280290', -- Itabaiana/SE
-            '280350', -- Lagarto/SE
-            -- '160030', -- Macapá/AP
-            '280480', -- Nossa Senhora do Socorro/SE
-            -- '230970', -- Pacatuba/CE
-            '231130', -- Quixadá/CE
-            '231140', -- Quixeramobim/CE
-            '150680' -- Santarém/PA
-            -- '261390', -- Serra Talhada/PE   
-        )
-)
+{{ selecionar_municipios_ativos(
+	relacao="raas_psicossocial_disseminacao",
+	cte_resultado="municipios_selecionados"
+) }},
+
+{{ limitar_quantidade_meses(
+	relacao="municipios_selecionados",
+	cte_resultado="final"
+) }}
 SELECT * FROM final

--- a/models/sources_apenas_municipios_participantes/sisab_conduta_problema_condicao_municipios_selecionados.sql
+++ b/models/sources_apenas_municipios_participantes/sisab_conduta_problema_condicao_municipios_selecionados.sql
@@ -1,0 +1,26 @@
+
+{#
+SPDX-FileCopyrightText: 2022 ImpulsoGov <contato@impulsogov.org>
+ 
+SPDX-License-Identifier: MIT
+#}
+
+
+WITH
+sisab_producao_conduta_problema_condicao AS (
+	SELECT * FROM {{ source("sisab", "sisab_producao_conduta_problema_condicao") }}
+),
+
+{{ selecionar_municipios_ativos(
+	relacao="sisab_producao_conduta_problema_condicao",
+	coluna_municipio_id="unidade_geografica_id",
+	cte_resultado="municipios_selecionados"
+) }},
+
+{{ limitar_quantidade_meses(
+	relacao="municipios_selecionados",
+	coluna_data="periodo_id",
+	coluna_municipio_id="unidade_geografica_id",
+	cte_resultado="final"
+) }}
+SELECT * FROM final

--- a/models/sources_apenas_municipios_participantes/sisab_conduta_problema_condicao_municipios_selecionados.yml
+++ b/models/sources_apenas_municipios_participantes/sisab_conduta_problema_condicao_municipios_selecionados.yml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2022 Impulso Gov <contato@impulsogov.org>
+#
+# SPDX-License-Identifier: MIT
+
+
+version: 2
+
+models:
+  - name: sisab_conduta_problema_condicao_municipios_selecionados
+    description: >
+      [...]
+    config:
+      grants:
+        select: ['saude_mental_analistas', 'saude_mental_integracao']
+      alias: sisab_conduta_problema_condicao_municipios_selecionados
+      enabled: true
+      indexes:
+        - columns: 
+          - "id"
+        - columns: 
+          - "periodo_id"
+        - columns: 
+          - "unidade_geografica_id"
+        - columns:
+          - "conduta"
+          - "problema_condicao_avaliada"
+          - "tipo_producao"
+      materialized: table
+      persist_docs:
+        relation: true
+      tags:
+        - "saude_mental"
+        - "sisab"
+        - "municipios_painel"

--- a/models/sources_apenas_municipios_participantes/sisab_por_tipo_equipe_tipo_producao_municipios_selecionados.sql
+++ b/models/sources_apenas_municipios_participantes/sisab_por_tipo_equipe_tipo_producao_municipios_selecionados.sql
@@ -1,0 +1,27 @@
+
+{#
+SPDX-FileCopyrightText: 2022 ImpulsoGov <contato@impulsogov.org>
+ 
+SPDX-License-Identifier: MIT
+#}
+
+
+WITH
+sisab_por_tipo_equipe_tipo_producao AS (
+	SELECT * FROM {{ source("sisab", "sisab_producao_municipios_por_tipo_equipe_por_tipo_producao") }}
+),
+
+{{ selecionar_municipios_ativos(
+	relacao="sisab_por_tipo_equipe_tipo_producao",
+	coluna_municipio_id="unidade_geografica_id",
+	cte_resultado="municipios_selecionados"
+) }},
+
+{{ limitar_quantidade_meses(
+	relacao="municipios_selecionados",
+	coluna_data="periodo_id",
+	coluna_municipio_id="unidade_geografica_id",
+	cte_resultado="final"
+) }}
+
+SELECT * FROM final

--- a/models/sources_apenas_municipios_participantes/sisab_por_tipo_equipe_tipo_producao_municipios_selecionados.yml
+++ b/models/sources_apenas_municipios_participantes/sisab_por_tipo_equipe_tipo_producao_municipios_selecionados.yml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2022 Impulso Gov <contato@impulsogov.org>
+#
+# SPDX-License-Identifier: MIT
+
+
+version: 2
+
+models:
+  - name: sisab_por_tipo_equipe_tipo_producao_municipios_selecionados
+    description: >
+      [...]
+    config:
+      grants:
+        select: ['saude_mental_analistas', 'saude_mental_integracao']
+      alias: sisab_por_tipo_equipe_tipo_producao_municipios_selecionados
+      enabled: true
+      indexes:
+        - columns: 
+          - "id"
+        - columns: 
+          - "periodo_id"
+        - columns: 
+          - "unidade_geografica_id"
+        - columns:
+          - "tipo_producao"
+          - "tipo_equipe"
+      materialized: table
+      persist_docs:
+        relation: true
+      tags:
+        - "saude_mental"
+        - "sisab"
+        - "municipios_painel"

--- a/models/sources_apenas_municipios_participantes/vinculos_profissionais_municipios_selecionados.sql
+++ b/models/sources_apenas_municipios_participantes/vinculos_profissionais_municipios_selecionados.sql
@@ -55,43 +55,19 @@ vinculos_profissionais AS (
         criacao_data,
         atualizacao_data
     FROM {{ source("scnes", "vinculos_profissionais") }}
-    WHERE estabelecimento_municipio_id_sus IN 
-        (
-            '150140', -- Belém/PA
-            '230190', -- Barbalha/CE
-            '230440', -- Fortaleza/CE (para Impulsolandia)
-            '231290', -- Sobral/CE
-            '261160', -- Recife/PE
-            '280030', -- Aracaju/SE
-            '292740', -- Salvador/BA
-            '315780', -- Santa Luzia/MG
-            '320500', -- Serra/ES
-            '320520', -- Vila Velha/ES  
-            -- '330490', -- São Gonçalo/RJ
-            -- '350950', -- Campinas/SP
-            '351640', -- Franco da Rocha/SP
-            '352590', -- Jundiaí/SP
-            -- '410480', -- Cascavel/PR
-            '410690', -- Curitiba/PR
-            '431440', -- Pelotas/RS
-            '431490', -- Porto Alegre/RS   
-            '520140',  -- Aparecida de Goiânia/GO 
+), 
 
-        -- MUNICIPIOS BNDES
-            -- '260120', -- Arcoverde/PE
-            -- '210005', -- Açailândia/MA
-            -- '150170', -- Bragança/PA
-            -- '230280', -- Canindé/CE
-            -- '280290', -- Itabaiana/SE
-            '280350', -- Lagarto/SE
-            -- '160030', -- Macapá/AP
-            '280480', -- Nossa Senhora do Socorro/SE
-            -- '230970', -- Pacatuba/CE
-            '231130', -- Quixadá/CE
-            '231140', -- Quixeramobim/CE
-            '150680' -- Santarém/PA
-            -- '261390', -- Serra Talhada/PE
+{{ selecionar_municipios_ativos(
+	relacao="vinculos_profissionais",
+    coluna_municipio_id="unidade_geografica_id",
+	cte_resultado="municipios_selecionados"
+) }},
 
-        )
-)
-SELECT * FROM vinculos_profissionais
+{{ limitar_quantidade_meses(
+	relacao="municipios_selecionados",
+    coluna_data="periodo_data_inicio",
+    coluna_municipio_id="unidade_geografica_id",
+	cte_resultado="final"
+) }}
+
+SELECT * FROM final

--- a/models/ultimas_competencias_disponiveis/sisab_producao_conduta_problema_condicao_ultima_competencia.sql
+++ b/models/ultimas_competencias_disponiveis/sisab_producao_conduta_problema_condicao_ultima_competencia.sql
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MIT
 
 WITH
 sisab_producao_conduta_problema_condicao AS (
-    SELECT * FROM {{ ref("sisab_producao_conduta_problema_condicao_municipios_selecionados") }} 
+    SELECT * FROM {{ ref("sisab_conduta_problema_condicao_municipios_selecionados") }} 
 ),
 periodos AS (
     SELECT * FROM {{ source('codigos', 'periodos') }}

--- a/models/ultimas_competencias_disponiveis/sisab_producao_conduta_problema_condicao_ultima_competencia.sql
+++ b/models/ultimas_competencias_disponiveis/sisab_producao_conduta_problema_condicao_ultima_competencia.sql
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MIT
 
 WITH
 sisab_producao_conduta_problema_condicao AS (
-    SELECT * FROM {{ source('sisab', 'sisab_producao_conduta_problema_condicao') }}
+    SELECT * FROM {{ ref("sisab_producao_conduta_problema_condicao_municipios_selecionados") }} 
 ),
 periodos AS (
     SELECT * FROM {{ source('codigos', 'periodos') }}

--- a/models/ultimas_competencias_disponiveis/sisab_producao_municipios_equipe_producao_ultima_competencia.sql
+++ b/models/ultimas_competencias_disponiveis/sisab_producao_municipios_equipe_producao_ultima_competencia.sql
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MIT
 
 WITH
 sisab_producao_municipios_por_tipo_equipe_por_tipo_producao AS (
-    SELECT * FROM {{ source('sisab', 'sisab_producao_municipios_por_tipo_equipe_por_tipo_producao') }}
+    SELECT * FROM {{ ref("sisab_por_tipo_equipe_tipo_producao_municipios_selecionados") }} 
 ),
 periodos AS (
     SELECT * FROM {{ source('codigos', 'periodos') }}


### PR DESCRIPTION
### Descrição

A adição de mais mumicípios ao painel de indicadores de saúde mental fez com que as bases de dados capturadas pelos ETLs aumentassem consideravelmente de tamanho, especialmente aquelas nos quais o download é feito por estado e não por município (SIASUS, SIHSUS e SCNES). 

Originalmente, todos os indicadores eram construídos consumindo diretamente do schema `dados_publicos` do banco analítico, implicando em tabelas finais que continham municípios parceiros e não parceiros do projeto; quanto mais municípios eram adicionados, maior o tempo de execução do DBT para gerar as tabelas de indicadores e maior o consumo de memória no banco. 
Em PR anterior a primeira medida tomada para reduzir o tempo de execução do DBT foi criar [modelos](https://github.com/ImpulsoGov/saude-mental-indicadores/tree/main/models/sources_apenas_municipios_participantes) que são cópias das estruturas das tabelas originais no banco analítico em `dados_publicos`, mas selecionando apenas os municípios parceiros, possibilitando que todos os indicadores fossem gerados a partir de uma fonte de dados reduzida apenas para os municípios ativos no projeto. 

Apesar da limitação de municípios, um segundo problema relacionado ao tamanho das tabelas ainda persistia: Todos os ETLs de Saúde Mental possuem como data de início das capturas o ano de 2016 ou 2017, sem limitação de data final; isso implica que, mesmo que o número de municípios ativos no painel fosse fixo, sem adição de novas parcerias, todas as tabelas geradas pelo DBT que consomem das sources continuariam crescendo a cada atualização, contendo os dados desde o início do ETL até o último período disponível.

Uma pesquisa foi feita com os usuários do painel e foi delimitado pelo time que mostraríamos dados apenas dos últimos 72 meses, sempre que entrar uma competência nova, a mais antiga deve ser excluída das tabelas de indicadores. Entretanto, os usuários ainda podem solicitar via formulário o  acesso a dados anteriores a 72 meses, portanto a modificação não poderia ser feita via ETL (que deve continuar guardando em dados_publicos as tabelas completas), mas sim via DBT, que gera todas as tabelas de indicadores.


### Objetivos

- Criar macro para fixar o período dos indicadores em 72 meses contados a partir da última competência
    - [feat: ✨ Cria macro para limitar quantidade de competências a partir da mais recente](https://github.com/ImpulsoGov/saude-mental-indicadores/commit/20e989923b68089429770b694b0c1455dc23826f) https://github.com/ImpulsoGov/saude-mental-indicadores/commit/20e989923b68089429770b694b0c1455dc23826f
    - [feat: ✨ Atualiza macro de limitar competências para lidar com campo de `periodo_id`](https://github.com/ImpulsoGov/saude-mental-indicadores/commit/75b681ed751583af0e951d1881b7a84c243e14cc) https://github.com/ImpulsoGov/saude-mental-indicadores/commit/75b681ed751583af0e951d1881b7a84c243e14cc

- Refatorar modelos de fontes de dados para facilitar a adição/exclusão de municípios, evitando erros de diferenças entre sources distintas e repetição de código
    -  [feat: ✨ Cria macro para selecionar municípios ativos no painel](https://github.com/ImpulsoGov/saude-mental-indicadores/commit/5495e8bb1477c93106b832fa4dd7c0593f345946) https://github.com/ImpulsoGov/saude-mental-indicadores/commit/5495e8bb1477c93106b832fa4dd7c0593f345946
    - [feat: ✨ Atualiza macro de selecionar municípios ativos para lidar com campo de `unidade_geografica_id`](https://github.com/ImpulsoGov/saude-mental-indicadores/commit/ed2d7f88d6714949746ba6887a641f198901d6a1) https://github.com/ImpulsoGov/saude-mental-indicadores/commit/ed2d7f88d6714949746ba6887a641f198901d6a1
    - [chore: 🍱 Adiciona source que aponta para tabela com municípios ativos no banco](https://github.com/ImpulsoGov/saude-mental-indicadores/commit/68d179837b26d393ee5b5830fadb5b8081c61ca3) https://github.com/ImpulsoGov/saude-mental-indicadores/commit/68d179837b26d393ee5b5830fadb5b8081c61ca3