### PR TITLE
Cria tabela de referência para listagem de períodos ausentes no painel

### DIFF
--- a/macros/classificar_categorias/classificar_caps_linha.sql
+++ b/macros/classificar_categorias/classificar_caps_linha.sql
@@ -11,7 +11,7 @@ SPDX-License-Identifier: MIT
     coluna_linha_idade="estabelecimento_linha_idade",
     coluna_estabelecimento_id="estabelecimento_id_scnes",
     todos_estabelecimentos_id="0000000",
-    todas_linhas_valor="Todas",
+    todas_linhas_valor="Todos",
     cte_resultado="com_linhas_cuidado"
 ) %}
 {%- set re = modules.re -%}

--- a/macros/utilidades/adicionar_datas_legiveis.sql
+++ b/macros/utilidades/adicionar_datas_legiveis.sql
@@ -46,7 +46,7 @@ EXTRACT ( MONTH FROM {{ coluna_periodo_data }} )
     {%- endif -%}
 
     {%- if tags is defined and 'adesao_mensal' in tags %}
-            WHERE tabela_referencia = 'caps_adesao_usuarios_perfil_cid'
+            WHERE tabela_referencia = 'caps_adesao_usuarios_perfil_cid' 
     {%- endif -%}
 
     {%- if tags is defined and 'adesao_acumulada' in tags %}

--- a/macros/utilidades/adicionar_datas_legiveis.sql
+++ b/macros/utilidades/adicionar_datas_legiveis.sql
@@ -9,23 +9,84 @@ SPDX-License-Identifier: MIT
     relacao,
     coluna_periodo_data="periodo_data_inicio",
     prefixo_colunas="",
-    cte_resultado="com_datas_legiveis"
+    cte_resultado="com_datas_legiveis",
+    tags=[]
 ) %}
+
 {%- set mes -%}
 EXTRACT ( MONTH FROM {{ coluna_periodo_data }} )
 {%- endset -%}
+
+
+{%- if tags is defined and 'caps_uso_externo' in tags %}
+
 {{ coluna_periodo_data -}}_ultimas_competencias AS (
     SELECT
-        DISTINCT ON (
-            unidade_geografica_id
-        )
-        unidade_geografica_id,
+        DISTINCT ON (t.unidade_geografica_id, t.unidade_geografica_id_sus, t.estabelecimento)
+        t.unidade_geografica_id,
+        t.unidade_geografica_id_sus,
+		t.estabelecimento,
         {{ coluna_periodo_data }} AS ultima_competencia
-    FROM {{ relacao }}
+    FROM {{ relacao }} t       
+    LEFT JOIN (
+        SELECT 
+            unidade_geografica_id_sus, estabelecimento
+        FROM {{ ref("configuracoes_estabelecimentos_ausentes_por_periodos") }}
+
+    {%- if tags is defined and 'usuarios_ativos' in tags %}
+            WHERE tabela_referencia = 'caps_usuarios_ativos_perfil_condicao_semsubtotais'
+    {%- endif -%}
+
+    {%- if tags is defined and 'usuarios_novos' in tags %}
+            WHERE tabela_referencia = 'caps_usuarios_novos_perfil_condicao'
+    {%- endif -%}
+
+    {%- if tags is defined and 'atendimentos_individuais' in tags %}
+            WHERE tabela_referencia = 'caps_usuarios_atendimentos_individuais_perfil_cid'
+    {%- endif -%}
+
+    {%- if tags is defined and 'adesao' in tags %}
+            WHERE tabela_referencia = 'caps_adesao_usuarios_perfil_cid'
+    {%- endif -%}
+
+    {%- if tags is defined and 'procedimentos_por_usuario' in tags %}
+            WHERE tabela_referencia = 'caps_procedimentos_por_usuario_por_tempo_servico'
+    {%- endif -%}
+
+    {%- if tags is defined and 'procedimentos_por_hora' in tags %}
+            WHERE tabela_referencia = 'caps_procedimentos_por_hora_resumo'
+    {%- endif -%}
+
+    {%- if tags is defined and 'procedimentos_por_tipo' in tags %}
+            WHERE tabela_referencia = 'caps_procedimentos_por_tipo'
+    {%- endif -%}
+
+        AND periodo = 'Último período'
+        ) AS tr
+    ON t.unidade_geografica_id_sus = tr.unidade_geografica_id_sus 
+        AND t.estabelecimento = tr.estabelecimento     	
+    WHERE tr.unidade_geografica_id_sus IS NULL    	
     ORDER BY
-        unidade_geografica_id,
+    	unidade_geografica_id,
+        unidade_geografica_id_sus,
+        estabelecimento,
         {{ coluna_periodo_data }} DESC
 ),
+
+{%- else -%}
+    {{ coluna_periodo_data -}}_ultimas_competencias AS (
+        SELECT
+            DISTINCT ON (unidade_geografica_id)
+            unidade_geografica_id,
+            {{ coluna_periodo_data }} AS ultima_competencia
+        FROM {{ relacao }}
+        ORDER BY
+            unidade_geografica_id,
+            {{ coluna_periodo_data }} DESC
+    ),
+{%- endif %}
+
+
 {{ cte_resultado }} AS (
     SELECT
         t.*,
@@ -70,7 +131,11 @@ EXTRACT ( MONTH FROM {{ coluna_periodo_data }} )
             to_char({{ coluna_periodo_data }}, 'YY')::numeric + {{ mes }}/100
         ) AS {{ prefixo_colunas -}}periodo_ordem
     FROM {{ relacao }} t
-    LEFT JOIN {{ coluna_periodo_data -}}_ultimas_competencias
+    LEFT JOIN {{ coluna_periodo_data -}}_ultimas_competencias uc
+{% if tags is defined and ('usuarios_ativos' in tags or 'usuarios_novos' in tags or 'atendimentos_individuais' in tags or 'adesao' in tags or 'procedimentos_por_usuario' in tags or 'procedimentos_por_hora' in tags or 'procedimentos_por_tipo' in tags) -%}
+    ON t.unidade_geografica_id = uc.unidade_geografica_id AND t.estabelecimento = uc.estabelecimento 
+{% else -%}
     USING (unidade_geografica_id)
+{%- endif -%}    
 )
 {%- endmacro -%}

--- a/macros/utilidades/adicionar_datas_legiveis.sql
+++ b/macros/utilidades/adicionar_datas_legiveis.sql
@@ -45,8 +45,12 @@ EXTRACT ( MONTH FROM {{ coluna_periodo_data }} )
             WHERE tabela_referencia = 'caps_usuarios_atendimentos_individuais_perfil_cid'
     {%- endif -%}
 
-    {%- if tags is defined and 'adesao' in tags %}
+    {%- if tags is defined and 'adesao_mensal' in tags %}
             WHERE tabela_referencia = 'caps_adesao_usuarios_perfil_cid'
+    {%- endif -%}
+
+    {%- if tags is defined and 'adesao_acumulada' in tags %}
+            WHERE tabela_referencia = 'caps_adesao_evasao_coortes_resumo'
     {%- endif -%}
 
     {%- if tags is defined and 'procedimentos_por_usuario' in tags %}
@@ -132,7 +136,7 @@ EXTRACT ( MONTH FROM {{ coluna_periodo_data }} )
         ) AS {{ prefixo_colunas -}}periodo_ordem
     FROM {{ relacao }} t
     LEFT JOIN {{ coluna_periodo_data -}}_ultimas_competencias uc
-{% if tags is defined and ('usuarios_ativos' in tags or 'usuarios_novos' in tags or 'atendimentos_individuais' in tags or 'adesao' in tags or 'procedimentos_por_usuario' in tags or 'procedimentos_por_hora' in tags or 'procedimentos_por_tipo' in tags) -%}
+{% if tags is defined and ('usuarios_ativos' in tags or 'usuarios_novos' in tags or 'atendimentos_individuais' in tags or 'adesao_mensal' in tags or 'adesao_acumulada' in tags or 'procedimentos_por_usuario' in tags or 'procedimentos_por_hora' in tags or 'procedimentos_por_tipo' in tags) -%}
     ON t.unidade_geografica_id = uc.unidade_geografica_id AND t.estabelecimento = uc.estabelecimento 
 {% else -%}
     USING (unidade_geografica_id)

--- a/macros/utilidades/adicionar_datas_legiveis.sql
+++ b/macros/utilidades/adicionar_datas_legiveis.sql
@@ -37,6 +37,10 @@ EXTRACT ( MONTH FROM {{ coluna_periodo_data }} )
             WHERE tabela_referencia = 'caps_usuarios_ativos_perfil_condicao_semsubtotais'
     {%- endif -%}
 
+    {%- if tags is defined and 'usuarios_ativos_resumo' in tags %}
+            WHERE tabela_referencia = 'caps_usuarios_ativos_por_estabelecimento_resumo'
+    {%- endif -%}
+
     {%- if tags is defined and 'usuarios_novos' in tags %}
             WHERE tabela_referencia = 'caps_usuarios_novos_perfil_condicao'
     {%- endif -%}
@@ -136,7 +140,7 @@ EXTRACT ( MONTH FROM {{ coluna_periodo_data }} )
         ) AS {{ prefixo_colunas -}}periodo_ordem
     FROM {{ relacao }} t
     LEFT JOIN {{ coluna_periodo_data -}}_ultimas_competencias uc
-{% if tags is defined and ('usuarios_ativos' in tags or 'usuarios_novos' in tags or 'atendimentos_individuais' in tags or 'adesao_mensal' in tags or 'adesao_acumulada' in tags or 'procedimentos_por_usuario' in tags or 'procedimentos_por_hora' in tags or 'procedimentos_por_tipo' in tags) -%}
+{% if tags is defined and ('usuarios_ativos' in tags or 'usuarios_ativos_resumo' in tags or 'usuarios_novos' in tags or 'atendimentos_individuais' in tags or 'adesao_mensal' in tags or 'adesao_acumulada' in tags or 'procedimentos_por_usuario' in tags or 'procedimentos_por_hora' in tags or 'procedimentos_por_tipo' in tags) -%}
     ON t.unidade_geografica_id = uc.unidade_geografica_id AND t.estabelecimento = uc.estabelecimento 
 {% else -%}
     USING (unidade_geografica_id)

--- a/macros/utilidades/preparar_uso_externo.sql
+++ b/macros/utilidades/preparar_uso_externo.sql
@@ -17,7 +17,8 @@ SPDX-License-Identifier: MIT
         "_nome",
         "_descricao"
     ],
-    cte_resultado="final"
+    cte_resultado="final",
+    tags=[]
 ) %}
 {%- set re = modules.re -%}
 {%- set colunas = [] -%}
@@ -134,7 +135,8 @@ SPDX-License-Identifier: MIT
 	relacao=ctes|last,
     coluna_periodo_data=coluna,
     prefixo_colunas=coluna_prefixo,
-	cte_resultado=cte
+	cte_resultado=cte,
+    tags=tags
 ) }},
 {%- set _ = colunas.append(coluna_prefixo + "periodo") -%}
 {%- set _ = colunas.append(coluna_prefixo + "nome_mes") -%}

--- a/models/caps/adesao/_caps_adesao_usuarios_evadiram.sql
+++ b/models/caps/adesao/_caps_adesao_usuarios_evadiram.sql
@@ -155,7 +155,7 @@ final AS (
         ]) }} AS id,
         *,
         now() AS atualizacao_data
-    FROM exceto_perfil_ambulatorial
+    FROM exceto_encaminhamentos_ambulatorio
 )
 
 SELECT * FROM final

--- a/models/caps/adesao/caps_adesao_evasao_coortes_resumo.sql
+++ b/models/caps/adesao/caps_adesao_evasao_coortes_resumo.sql
@@ -5,10 +5,13 @@ SPDX-License-Identifier: MIT
 #}
 
 -- depends_on: {{ ref('_caps_adesao_evasao_coortes_resumo') }}
+-- depends_on: {{ ref('configuracoes_estabelecimentos_ausentes_por_periodos') }}
+{%- set tags = ['caps_uso_externo', 'adesao'] %}
 
 WITH
 {{ preparar_uso_externo(
 	relacao="_caps_adesao_evasao_coortes_resumo",
-	cte_resultado="final"
+	cte_resultado="final",
+	tags=tags 
 ) }}
 SELECT * FROM final

--- a/models/caps/adesao/caps_adesao_evasao_coortes_resumo.sql
+++ b/models/caps/adesao/caps_adesao_evasao_coortes_resumo.sql
@@ -6,7 +6,7 @@ SPDX-License-Identifier: MIT
 
 -- depends_on: {{ ref('_caps_adesao_evasao_coortes_resumo') }}
 -- depends_on: {{ ref('configuracoes_estabelecimentos_ausentes_por_periodos') }}
-{%- set tags = ['caps_uso_externo', 'adesao'] %}
+{%- set tags = ['caps_uso_externo', 'adesao_acumulada'] %}
 
 WITH
 {{ preparar_uso_externo(

--- a/models/caps/adesao/caps_adesao_evasao_mensal.sql
+++ b/models/caps/adesao/caps_adesao_evasao_mensal.sql
@@ -6,7 +6,7 @@ SPDX-License-Identifier: MIT
 
 -- depends_on: {{ ref('_caps_adesao_evasao_mensal') }}
 -- depends_on: {{ ref('configuracoes_estabelecimentos_ausentes_por_periodos') }}
-{%- set tags = ['caps_uso_externo', 'adesao'] %}
+{%- set tags = ['caps_uso_externo', 'adesao_mensal'] %}
 
 WITH
 {{ preparar_uso_externo(

--- a/models/caps/adesao/caps_adesao_evasao_mensal.sql
+++ b/models/caps/adesao/caps_adesao_evasao_mensal.sql
@@ -5,10 +5,13 @@ SPDX-License-Identifier: MIT
 #}
 
 -- depends_on: {{ ref('_caps_adesao_evasao_mensal') }}
+-- depends_on: {{ ref('configuracoes_estabelecimentos_ausentes_por_periodos') }}
+{%- set tags = ['caps_uso_externo', 'adesao'] %}
 
 WITH
 {{ preparar_uso_externo(
 	relacao="_caps_adesao_evasao_mensal",
-	cte_resultado="final"
+	cte_resultado="final",
+	tags=tags 
 ) }}
 SELECT * FROM final

--- a/models/caps/adesao/sem_subtotais_linha_idade/caps_adesao_usuarios_perfil_cid.sql
+++ b/models/caps/adesao/sem_subtotais_linha_idade/caps_adesao_usuarios_perfil_cid.sql
@@ -6,7 +6,7 @@ SPDX-License-Identifier: MIT
 
 -- depends_on: {{ ref('_caps_adesao_usuarios_perfil_cid') }}
 -- depends_on: {{ ref('configuracoes_estabelecimentos_ausentes_por_periodos') }}
-{%- set tags = ['caps_uso_externo', 'adesao'] %}
+{%- set tags = ['caps_uso_externo', 'adesao_mensal'] %}
 
 WITH
 {{ preparar_uso_externo(

--- a/models/caps/adesao/sem_subtotais_linha_idade/caps_adesao_usuarios_perfil_cid.sql
+++ b/models/caps/adesao/sem_subtotais_linha_idade/caps_adesao_usuarios_perfil_cid.sql
@@ -5,10 +5,13 @@ SPDX-License-Identifier: MIT
 #}
 
 -- depends_on: {{ ref('_caps_adesao_usuarios_perfil_cid') }}
+-- depends_on: {{ ref('configuracoes_estabelecimentos_ausentes_por_periodos') }}
+{%- set tags = ['caps_uso_externo', 'adesao'] %}
 
 WITH
 {{ preparar_uso_externo(
 	relacao="_caps_adesao_usuarios_perfil_cid",
-	cte_resultado="final"
+	cte_resultado="final",
+	tags=tags 
 ) }}
 SELECT * FROM final

--- a/models/caps/adesao/sem_subtotais_linha_idade/caps_adesao_usuarios_perfil_genero_idade.sql
+++ b/models/caps/adesao/sem_subtotais_linha_idade/caps_adesao_usuarios_perfil_genero_idade.sql
@@ -6,7 +6,7 @@ SPDX-License-Identifier: MIT
 
 -- depends_on: {{ ref('_caps_adesao_usuarios_perfil_genero_idade') }}
 -- depends_on: {{ ref('configuracoes_estabelecimentos_ausentes_por_periodos') }}
-{%- set tags = ['caps_uso_externo', 'adesao'] %}
+{%- set tags = ['caps_uso_externo', 'adesao_mensal'] %}
 
 WITH
 {{ preparar_uso_externo(

--- a/models/caps/adesao/sem_subtotais_linha_idade/caps_adesao_usuarios_perfil_genero_idade.sql
+++ b/models/caps/adesao/sem_subtotais_linha_idade/caps_adesao_usuarios_perfil_genero_idade.sql
@@ -5,10 +5,13 @@ SPDX-License-Identifier: MIT
 #}
 
 -- depends_on: {{ ref('_caps_adesao_usuarios_perfil_genero_idade') }}
+-- depends_on: {{ ref('configuracoes_estabelecimentos_ausentes_por_periodos') }}
+{%- set tags = ['caps_uso_externo', 'adesao'] %}
 
 WITH
 {{ preparar_uso_externo(
 	relacao="_caps_adesao_usuarios_perfil_genero_idade",
-	cte_resultado="final"
+	cte_resultado="final",
+	tags=tags 
 ) }}
 SELECT * FROM final

--- a/models/caps/atendimentos_individuais/caps_atendimentos_individuais_por_caps.sql
+++ b/models/caps/atendimentos_individuais/caps_atendimentos_individuais_por_caps.sql
@@ -4,10 +4,13 @@ SPDX-FileCopyrightText: 2022 ImpulsoGov <contato@impulsogov.org>
 SPDX-License-Identifier: MIT
 #}
 
+-- depends_on: {{ ref('configuracoes_estabelecimentos_ausentes_por_periodos') }}
+{%- set tags = ['caps_uso_externo', 'atendimentos_individuais'] %}
 
 WITH
 {{ preparar_uso_externo(
 	relacao="_caps_atendimentos_individuais_por_caps",
-	cte_resultado="final"
+	cte_resultado="final",
+	tags=tags 
 ) }}
 SELECT * FROM final

--- a/models/caps/atendimentos_individuais/perfil/caps_usuarios_atendimentos_individuais_perfil_cid.sql
+++ b/models/caps/atendimentos_individuais/perfil/caps_usuarios_atendimentos_individuais_perfil_cid.sql
@@ -5,10 +5,13 @@ SPDX-License-Identifier: MIT
 #}
 
 -- depends_on: {{ ref('_caps_usuarios_atendimentos_individuais_perfil_cid') }}
+-- depends_on: {{ ref('configuracoes_estabelecimentos_ausentes_por_periodos') }}
+{%- set tags = ['caps_uso_externo', 'atendimentos_individuais'] %}
 
 WITH
 {{ preparar_uso_externo(
 	relacao="_caps_usuarios_atendimentos_individuais_perfil_cid",
-	cte_resultado="final"
+	cte_resultado="final",
+	tags=tags 
 ) }}
 SELECT * FROM final

--- a/models/caps/atendimentos_individuais/perfil/caps_usuarios_atendimentos_individuais_perfil_genero_idade.sql
+++ b/models/caps/atendimentos_individuais/perfil/caps_usuarios_atendimentos_individuais_perfil_genero_idade.sql
@@ -5,10 +5,13 @@ SPDX-License-Identifier: MIT
 #}
 
 -- depends_on: {{ ref('_caps_usuarios_atendimentos_individuais_perfil_genero_idade') }}
+-- depends_on: {{ ref('configuracoes_estabelecimentos_ausentes_por_periodos') }}
+{%- set tags = ['caps_uso_externo', 'atendimentos_individuais'] %}
 
 WITH
 {{ preparar_uso_externo(
 	relacao="_caps_usuarios_atendimentos_individuais_perfil_genero_idade",
-	cte_resultado="final"
+	cte_resultado="final",
+	tags=tags 
 ) }}
 SELECT * FROM final

--- a/models/caps/atendimentos_individuais/perfil/caps_usuarios_atendimentos_individuais_perfil_raca.sql
+++ b/models/caps/atendimentos_individuais/perfil/caps_usuarios_atendimentos_individuais_perfil_raca.sql
@@ -5,10 +5,14 @@ SPDX-License-Identifier: MIT
 #}
 
 -- depends_on: {{ ref('_caps_usuarios_atendimentos_individuais_perfil_raca') }}
+-- depends_on: {{ ref('configuracoes_estabelecimentos_ausentes_por_periodos') }}
+
+{%- set tags = ['caps_uso_externo', 'atendimentos_individuais'] %}
 
 WITH
 {{ preparar_uso_externo(
 	relacao="_caps_usuarios_atendimentos_individuais_perfil_raca",
-	cte_resultado="final"
+	cte_resultado="final",
+	tags=tags 
 ) }}
 SELECT * FROM final

--- a/models/caps/caps_resumo_totais_por_municipio.sql
+++ b/models/caps/caps_resumo_totais_por_municipio.sql
@@ -30,59 +30,110 @@ caps_procedimentos_por_usuario_por_tempo_servico_resumo AS (
 caps_procedimentos_por_hora_resumo AS (
     SELECT * FROM {{ ref('caps_procedimentos_por_hora_resumo') }}
 ),
+
 usuarios_ativos_resumo AS (
     SELECT
+        t.unidade_geografica_id_sus,
+        t.tornandose_inativos,
+        t.dif_tornandose_inativos_anterior,
+        t.ativos_mes,
+        t.dif_ativos_mes_anterior,
+        t.periodo as periodo_ativos,
+        t.nome_mes as nome_mes_ativos
+    FROM caps_usuarios_ativos_por_estabelecimento_resumo t
+    INNER JOIN (
+        SELECT
             unidade_geografica_id_sus,
-            tornandose_inativos,
-            dif_tornandose_inativos_anterior,
-            ativos_mes,
-            dif_ativos_mes_anterior,
-            periodo as periodo_ativos,
-            nome_mes as nome_mes_ativos
+            MAX(periodo_ordem) AS max_periodo_ordem
         FROM caps_usuarios_ativos_por_estabelecimento_resumo
         WHERE estabelecimento = 'Todos'
             AND estabelecimento_linha_perfil = 'Todos'
             AND estabelecimento_linha_idade = 'Todos'
-            AND periodo = 'Último período'
+        GROUP BY unidade_geografica_id_sus
+    ) AS p ON t.unidade_geografica_id_sus = p.unidade_geografica_id_sus
+        AND t.periodo_ordem = p.max_periodo_ordem
+    WHERE t.estabelecimento = 'Todos'
+        AND t.estabelecimento_linha_perfil = 'Todos'
+        AND t.estabelecimento_linha_idade = 'Todos'
 ),
+
 usuarios_novos_resumo AS (
     SELECT
-        unidade_geografica_id_sus,
-        usuarios_novos,
-        dif_usuarios_novos_anterior,
-        periodo as periodo_novos,
-        nome_mes as nome_mes_novos
-    FROM caps_usuarios_novos_resumo
-    WHERE estabelecimento = 'Todos' AND estabelecimento_linha_perfil = 'Todos' AND estabelecimento_linha_idade = 'Todos' AND periodo = 'Último período'
+        t.unidade_geografica_id_sus,
+        t.usuarios_novos,
+        t.dif_usuarios_novos_anterior,
+        t.periodo as periodo_novos,
+        t.nome_mes as nome_mes_novos
+    FROM caps_usuarios_novos_resumo t
+    INNER JOIN (
+        SELECT
+            unidade_geografica_id_sus,
+            MAX(periodo_ordem) AS max_periodo_ordem
+        FROM caps_usuarios_novos_resumo 
+        WHERE estabelecimento = 'Todos'
+            AND estabelecimento_linha_perfil = 'Todos'
+            AND estabelecimento_linha_idade = 'Todos'
+        GROUP BY unidade_geografica_id_sus
+    ) AS p ON t.unidade_geografica_id_sus = p.unidade_geografica_id_sus
+        AND t.periodo_ordem = p.max_periodo_ordem
+    WHERE t.estabelecimento = 'Todos' 
+        AND t.estabelecimento_linha_perfil = 'Todos' 
+        AND t.estabelecimento_linha_idade = 'Todos' 
+        
 ),
+
 nao_adesao_resumo AS (
     SELECT
-        unidade_geografica_id_sus,
-        usuarios_coorte_nao_aderiram_perc AS usuarios_coorte_nao_aderiram,
-		maior_taxa_estabelecimento as maior_taxa_estabelecimento_nao_adesao,
-		maior_taxa_perc as maior_taxa_nao_adesao,
-		predominio_sexo,
-		predominio_faixa_etaria,
-		predominio_condicao_grupo_descricao_curta_cid10,
-		a_partir_do_mes,
-		a_partir_do_ano,
-		ate_mes,
-		ate_ano
-    FROM caps_adesao_evasao_coortes_resumo
-    WHERE estabelecimento = 'Todos' AND periodo = 'Último período'
+        t.unidade_geografica_id_sus,
+        t.usuarios_coorte_nao_aderiram_perc AS usuarios_coorte_nao_aderiram,
+		t.maior_taxa_estabelecimento as maior_taxa_estabelecimento_nao_adesao,
+		t.maior_taxa_perc as maior_taxa_nao_adesao,
+		t.predominio_sexo,
+		t.predominio_faixa_etaria,
+		t.predominio_condicao_grupo_descricao_curta_cid10,
+		t.a_partir_do_mes,
+		t.a_partir_do_ano,
+		t.ate_mes,
+		t.ate_ano
+    FROM caps_adesao_evasao_coortes_resumo t
+    INNER JOIN (
+        SELECT
+            unidade_geografica_id_sus,
+            MAX(periodo_ordem) AS max_periodo_ordem
+        FROM caps_adesao_evasao_coortes_resumo 
+        WHERE estabelecimento = 'Todos'
+        GROUP BY unidade_geografica_id_sus
+    ) AS p ON t.unidade_geografica_id_sus = p.unidade_geografica_id_sus
+        AND t.periodo_ordem = p.max_periodo_ordem
+    WHERE t.estabelecimento = 'Todos' 
 ),
+
 atendimentos_individuais_resumo AS (
     SELECT
-        unidade_geografica_id_sus,
-        perc_apenas_atendimentos_individuais,
-        dif_perc_apenas_atendimentos_individuais,
-        maior_taxa AS maior_taxa_atendimentos_individuais,
-        maior_taxa_estabelecimento AS maior_taxa_estabelecimento_atendimentos_individuais,
-        periodo as periodo_atendimentos_individuais,
-        nome_mes as nome_mes_atendimentos_individuais
-    FROM caps_atendimentos_individuais_por_caps
-    WHERE estabelecimento = 'Todos' AND estabelecimento_linha_perfil = 'Todos' AND estabelecimento_linha_idade = 'Todos' AND periodo = 'Último período'
+        t.unidade_geografica_id_sus,
+        t.perc_apenas_atendimentos_individuais,
+        t.dif_perc_apenas_atendimentos_individuais,
+        t.maior_taxa AS maior_taxa_atendimentos_individuais,
+        t.maior_taxa_estabelecimento AS maior_taxa_estabelecimento_atendimentos_individuais,
+        t.periodo as periodo_atendimentos_individuais,
+        t.nome_mes as nome_mes_atendimentos_individuais
+    FROM caps_atendimentos_individuais_por_caps t
+    INNER JOIN (
+        SELECT
+            unidade_geografica_id_sus,
+            MAX(periodo_ordem) AS max_periodo_ordem
+        FROM caps_atendimentos_individuais_por_caps
+        WHERE estabelecimento = 'Todos'
+            AND estabelecimento_linha_perfil = 'Todos'
+            AND estabelecimento_linha_idade = 'Todos'
+        GROUP BY unidade_geografica_id_sus
+    ) AS p ON t.unidade_geografica_id_sus = p.unidade_geografica_id_sus
+        AND t.periodo_ordem = p.max_periodo_ordem    
+    WHERE t.estabelecimento = 'Todos' 
+        AND t.estabelecimento_linha_perfil = 'Todos' 
+        AND t.estabelecimento_linha_idade = 'Todos' 
 ),
+
 atendimentos_individuais_perfil_resumo AS (
     SELECT
         unidade_geografica_id_sus,
@@ -97,16 +148,30 @@ atendimentos_individuais_perfil_resumo AS (
 ),
 procedimentos_por_usuario_estabelecimento_resumo AS (
     SELECT
-        unidade_geografica_id_sus,
-        maior_taxa AS maior_taxa_procedimentos_por_usuario,
-        maior_taxa_estabelecimento AS maior_taxa_estabelecimento_procedimentos_por_usuario,
-        procedimentos_por_usuario,
-        dif_procedimentos_por_usuario_anterior_perc,
-        periodo as periodo_proced_usuario,
-        nome_mes as nome_mes_proced_usuario
-    FROM caps_procedimentos_por_usuario_por_estabelecimento
-    WHERE estabelecimento = 'Todos' AND estabelecimento_linha_perfil = 'Todos' AND estabelecimento_linha_idade = 'Todos' AND periodo = 'Último período'
+        t.unidade_geografica_id_sus,
+        t.maior_taxa AS maior_taxa_procedimentos_por_usuario,
+        t.maior_taxa_estabelecimento AS maior_taxa_estabelecimento_procedimentos_por_usuario,
+        t.procedimentos_por_usuario,
+        t.dif_procedimentos_por_usuario_anterior_perc,
+        t.periodo as periodo_proced_usuario,
+        t.nome_mes as nome_mes_proced_usuario
+    FROM caps_procedimentos_por_usuario_por_estabelecimento t
+    INNER JOIN (
+        SELECT
+            unidade_geografica_id_sus,
+            MAX(periodo_ordem) AS max_periodo_ordem
+        FROM caps_procedimentos_por_usuario_por_estabelecimento
+        WHERE estabelecimento = 'Todos'
+            AND estabelecimento_linha_perfil = 'Todos'
+            AND estabelecimento_linha_idade = 'Todos'
+        GROUP BY unidade_geografica_id_sus
+    ) AS p ON t.unidade_geografica_id_sus = p.unidade_geografica_id_sus
+        AND t.periodo_ordem = p.max_periodo_ordem
+    WHERE t.estabelecimento = 'Todos' 
+        AND t.estabelecimento_linha_perfil = 'Todos' 
+        AND t.estabelecimento_linha_idade = 'Todos' 
 ),
+
 procedimentos_por_usuario_tempo_servico_resumo AS (
     SELECT
         unidade_geografica_id_sus,
@@ -115,19 +180,36 @@ procedimentos_por_usuario_tempo_servico_resumo AS (
     FROM caps_procedimentos_por_usuario_por_tempo_servico_resumo
     WHERE estabelecimento = 'Todos'
 ),
+
 procedimentos_por_hora_resumo AS (
     SELECT
-        unidade_geografica_id_sus,
-        procedimentos_registrados_total,
-        dif_procedimentos_registrados_total_anterior,
-        procedimentos_registrados_bpa,
-        dif_procedimentos_registrados_bpa_anterior,
-        procedimentos_registrados_raas,
-        dif_procedimentos_registrados_raas_anterior,
-        periodo as periodo_procedimentos_hora,
-        nome_mes as nome_mes_procedimentos_hora
-    FROM caps_procedimentos_por_hora_resumo
-    WHERE estabelecimento = 'Todos' AND estabelecimento_linha_perfil = 'Todos' AND estabelecimento_linha_idade = 'Todos' AND periodo = 'Último período' AND ocupacao = 'Todas'
+        t.unidade_geografica_id_sus,
+        t.procedimentos_registrados_total,
+        t.dif_procedimentos_registrados_total_anterior,
+        t.procedimentos_registrados_bpa,
+        t.dif_procedimentos_registrados_bpa_anterior,
+        t.procedimentos_registrados_raas,
+        t.dif_procedimentos_registrados_raas_anterior,
+        t.periodo as periodo_procedimentos_hora,
+        t.nome_mes as nome_mes_procedimentos_hora
+    FROM caps_procedimentos_por_hora_resumo t
+    INNER JOIN (
+        SELECT
+            unidade_geografica_id_sus,
+            MAX(periodo_ordem) AS max_periodo_ordem
+        FROM caps_procedimentos_por_hora_resumo
+        WHERE estabelecimento = 'Todos'
+            AND estabelecimento_linha_perfil = 'Todos'
+            AND estabelecimento_linha_idade = 'Todos'
+            AND ocupacao = 'Todas'
+        GROUP BY unidade_geografica_id_sus
+    ) AS p ON t.unidade_geografica_id_sus = p.unidade_geografica_id_sus
+        AND t.periodo_ordem = p.max_periodo_ordem
+    WHERE t.estabelecimento = 'Todos' 
+        AND t.estabelecimento_linha_perfil = 'Todos' 
+        AND t.estabelecimento_linha_idade = 'Todos' 
+        AND periodo = 'Último período' 
+        AND t.ocupacao = 'Todas'
 ),
 intermediaria AS (
     SELECT *

--- a/models/caps/procedimentos_por_usuario/caps_procedimentos_por_usuario_por_estabelecimento.sql
+++ b/models/caps/procedimentos_por_usuario/caps_procedimentos_por_usuario_por_estabelecimento.sql
@@ -5,11 +5,14 @@ SPDX-License-Identifier: MIT
 #}
 
 -- depends_on: {{ ref('_caps_procedimentos_por_usuario_por_estabelecimento') }}
+-- depends_on: {{ ref('configuracoes_estabelecimentos_ausentes_por_periodos') }}
+{%- set tags = ['caps_uso_externo', 'procedimentos_por_usuario'] %}
 
 WITH
 {{ preparar_uso_externo(
 	relacao="_caps_procedimentos_por_usuario_por_estabelecimento",
-	cte_resultado="intermediaria"
+	cte_resultado="intermediaria",
+	tags=tags 
 ) }},
 final AS (
 	SELECT 

--- a/models/caps/procedimentos_por_usuario/caps_procedimentos_por_usuario_por_tempo_servico.sql
+++ b/models/caps/procedimentos_por_usuario/caps_procedimentos_por_usuario_por_tempo_servico.sql
@@ -5,10 +5,13 @@ SPDX-License-Identifier: MIT
 #}
 
 -- depends_on: {{ ref('_caps_procedimentos_por_usuario_por_tempo_servico') }}
+-- depends_on: {{ ref('configuracoes_estabelecimentos_ausentes_por_periodos') }}
+{%- set tags = ['caps_uso_externo', 'procedimentos_por_usuario'] %}
 
 WITH
 {{ preparar_uso_externo(
 	relacao="_caps_procedimentos_por_usuario_por_tempo_servico",
-	cte_resultado="final"
+	cte_resultado="final",
+	tags=tags 
 ) }}
 SELECT * FROM final

--- a/models/caps/producao/caps_procedimentos_por_hora_resumo.sql
+++ b/models/caps/producao/caps_procedimentos_por_hora_resumo.sql
@@ -5,10 +5,13 @@ SPDX-License-Identifier: MIT
 #}
 
 -- depends_on: {{ ref('_caps_procedimentos_por_hora_resumo') }}
+-- depends_on: {{ ref('configuracoes_estabelecimentos_ausentes_por_periodos') }}
+{%- set tags = ['caps_uso_externo', 'procedimentos_por_hora'] %}
 
 WITH
 {{ preparar_uso_externo(
 	relacao="_caps_procedimentos_por_hora_resumo",
-	cte_resultado="final"
+	cte_resultado="final",
+	tags=tags 
 ) }}
 SELECT * FROM final

--- a/models/caps/producao/caps_procedimentos_por_tipo.sql
+++ b/models/caps/producao/caps_procedimentos_por_tipo.sql
@@ -5,10 +5,13 @@ SPDX-License-Identifier: MIT
 #}
 
 -- depends_on: {{ ref('_caps_procedimentos_por_tipo') }}
+-- depends_on: {{ ref('configuracoes_estabelecimentos_ausentes_por_periodos') }}
+{%- set tags = ['caps_uso_externo', 'procedimentos_por_tipo'] %}
 
 WITH
 {{ preparar_uso_externo(
 	relacao="_caps_procedimentos_por_tipo",
-	cte_resultado="final"
+	cte_resultado="final",
+	tags=tags 
 ) }}
 SELECT * FROM final

--- a/models/caps/usuarios_ativos/caps_usuarios_ativos_por_estabelecimento_resumo.sql
+++ b/models/caps/usuarios_ativos/caps_usuarios_ativos_por_estabelecimento_resumo.sql
@@ -5,10 +5,13 @@ SPDX-License-Identifier: MIT
 #}
 
 -- depends_on: {{ ref('_caps_usuarios_ativos_por_estabelecimento_resumo') }}
+-- depends_on: {{ ref('configuracoes_estabelecimentos_ausentes_por_periodos') }}
+{%- set tags = ['caps_uso_externo', 'usuarios_ativos_resumo'] %}
 
 WITH
 {{ preparar_uso_externo(
 	relacao="_caps_usuarios_ativos_por_estabelecimento_resumo",
-	cte_resultado="final"
+	cte_resultado="final",
+	tags=tags 
 ) }}
 SELECT * FROM final

--- a/models/caps/usuarios_ativos/perfil/sem_subtotais_linha_idade/caps_usuarios_ativos_perfil_cid_semsubtotais.sql
+++ b/models/caps/usuarios_ativos/perfil/sem_subtotais_linha_idade/caps_usuarios_ativos_perfil_cid_semsubtotais.sql
@@ -5,10 +5,13 @@ SPDX-License-Identifier: MIT
 #}
 
 -- depends_on: {{ ref('_caps_usuarios_ativos_perfil_cid_semsubtotais') }}
+-- depends_on: {{ ref('configuracoes_estabelecimentos_ausentes_por_periodos') }}
+{%- set tags = ['caps_uso_externo', 'usuarios_ativos'] %}
 
 WITH
 {{ preparar_uso_externo(
 	relacao="_caps_usuarios_ativos_perfil_cid_semsubtotais",
-	cte_resultado="final"
+	cte_resultado="final",
+	tags=tags 
 ) }}
 SELECT * FROM final

--- a/models/caps/usuarios_ativos/perfil/sem_subtotais_linha_idade/caps_usuarios_ativos_perfil_condicao_semsubtotais.sql
+++ b/models/caps/usuarios_ativos/perfil/sem_subtotais_linha_idade/caps_usuarios_ativos_perfil_condicao_semsubtotais.sql
@@ -5,10 +5,13 @@ SPDX-License-Identifier: MIT
 #}
 
 -- depends_on: {{ ref('_caps_usuarios_ativos_perfil_condicao_semsubtotais') }}
+-- depends_on: {{ ref('configuracoes_estabelecimentos_ausentes_por_periodos') }}
+{%- set tags = ['caps_uso_externo', 'usuarios_ativos'] %}
 
 WITH
 {{ preparar_uso_externo(
 	relacao="_caps_usuarios_ativos_perfil_condicao_semsubtotais",
-	cte_resultado="final"
+	cte_resultado="final",
+	tags=tags 
 ) }}
 SELECT * FROM final

--- a/models/caps/usuarios_ativos/perfil/sem_subtotais_linha_idade/caps_usuarios_ativos_perfil_genero_idade_semsubtotais.sql
+++ b/models/caps/usuarios_ativos/perfil/sem_subtotais_linha_idade/caps_usuarios_ativos_perfil_genero_idade_semsubtotais.sql
@@ -5,10 +5,13 @@ SPDX-License-Identifier: MIT
 #}
 
 -- depends_on: {{ ref('_caps_usuarios_ativos_perfil_genero_idade_semsubtotais') }}
+-- depends_on: {{ ref('configuracoes_estabelecimentos_ausentes_por_periodos') }}
+{%- set tags = ['caps_uso_externo', 'usuarios_ativos'] %}
 
 WITH
 {{ preparar_uso_externo(
 	relacao="_caps_usuarios_ativos_perfil_genero_idade_semsubtotais",
-	cte_resultado="final"
+	cte_resultado="final",
+	tags=tags 
 ) }}
 SELECT * FROM final

--- a/models/caps/usuarios_ativos/perfil/sem_subtotais_linha_idade/caps_usuarios_ativos_perfil_raca_semsubtotais.sql
+++ b/models/caps/usuarios_ativos/perfil/sem_subtotais_linha_idade/caps_usuarios_ativos_perfil_raca_semsubtotais.sql
@@ -5,10 +5,13 @@ SPDX-License-Identifier: MIT
 #}
 
 -- depends_on: {{ ref('_caps_usuarios_ativos_perfil_raca_semsubtotais') }}
+-- depends_on: {{ ref('configuracoes_estabelecimentos_ausentes_por_periodos') }}
+{%- set tags = ['caps_uso_externo', 'usuarios_ativos'] %}
 
 WITH
 {{ preparar_uso_externo(
 	relacao="_caps_usuarios_ativos_perfil_raca_semsubtotais",
-	cte_resultado="final"
+	cte_resultado="final",
+	tags=tags 
 ) }}
 SELECT * FROM final

--- a/models/caps/usuarios_novos/sem_subtotais_linha_idade/caps_usuarios_novos_perfil_cid_semsubtotais.sql
+++ b/models/caps/usuarios_novos/sem_subtotais_linha_idade/caps_usuarios_novos_perfil_cid_semsubtotais.sql
@@ -5,10 +5,13 @@ SPDX-License-Identifier: MIT
 #}
 
 -- depends_on: {{ ref('_caps_usuarios_novos_perfil_cid_semsubtotais') }}
+-- depends_on: {{ ref('configuracoes_estabelecimentos_ausentes_por_periodos') }}
+{%- set tags = ['caps_uso_externo', 'usuarios_novos'] %}
 
 WITH
 {{ preparar_uso_externo(
 	relacao="_caps_usuarios_novos_perfil_cid_semsubtotais",
-	cte_resultado="final"
+	cte_resultado="final",
+	tags=tags 
 ) }}
 SELECT * FROM final

--- a/models/caps/usuarios_novos/sem_subtotais_linha_idade/caps_usuarios_novos_perfil_condicao_semsubtotais.sql
+++ b/models/caps/usuarios_novos/sem_subtotais_linha_idade/caps_usuarios_novos_perfil_condicao_semsubtotais.sql
@@ -5,10 +5,13 @@ SPDX-License-Identifier: MIT
 #}
 
 -- depends_on: {{ ref('_caps_usuarios_novos_perfil_condicao_semsubtotais') }}
+-- depends_on: {{ ref('configuracoes_estabelecimentos_ausentes_por_periodos') }}
+{%- set tags = ['caps_uso_externo', 'usuarios_novos'] %}
 
 WITH
 {{ preparar_uso_externo(
 	relacao="_caps_usuarios_novos_perfil_condicao_semsubtotais",
-	cte_resultado="final"
+	cte_resultado="final",
+	tags=tags 
 ) }}
 SELECT * FROM final

--- a/models/caps/usuarios_novos/sem_subtotais_linha_idade/caps_usuarios_novos_perfil_genero_idade_semsubtotais.sql
+++ b/models/caps/usuarios_novos/sem_subtotais_linha_idade/caps_usuarios_novos_perfil_genero_idade_semsubtotais.sql
@@ -5,10 +5,13 @@ SPDX-License-Identifier: MIT
 #}
 
 -- depends_on: {{ ref('_caps_usuarios_novos_perfil_genero_idade_semsubtotais') }}
+-- depends_on: {{ ref('configuracoes_estabelecimentos_ausentes_por_periodos') }}
+{%- set tags = ['caps_uso_externo', 'usuarios_novos'] %}
 
 WITH
 {{ preparar_uso_externo(
 	relacao="_caps_usuarios_novos_perfil_genero_idade_semsubtotais",
-	cte_resultado="final"
+	cte_resultado="final",
+	tags=tags 
 ) }}
 SELECT * FROM final

--- a/models/caps/usuarios_novos/sem_subtotais_linha_idade/caps_usuarios_novos_perfil_raca_semsubtotais.sql
+++ b/models/caps/usuarios_novos/sem_subtotais_linha_idade/caps_usuarios_novos_perfil_raca_semsubtotais.sql
@@ -5,10 +5,13 @@ SPDX-License-Identifier: MIT
 #}
 
 -- depends_on: {{ ref('_caps_usuarios_novos_perfil_raca_semsubtotais') }}
+-- depends_on: {{ ref('configuracoes_estabelecimentos_ausentes_por_periodos') }}
+{%- set tags = ['caps_uso_externo', 'usuarios_novos'] %}
 
 WITH
 {{ preparar_uso_externo(
 	relacao="_caps_usuarios_novos_perfil_raca_semsubtotais",
-	cte_resultado="final"
+	cte_resultado="final",
+	tags=tags 
 ) }}
 SELECT * FROM final

--- a/models/caps/utilitarios_configuracoes/_configuracoes_estabelecimentos_ausentes_por_periodos.sql
+++ b/models/caps/utilitarios_configuracoes/_configuracoes_estabelecimentos_ausentes_por_periodos.sql
@@ -1,0 +1,215 @@
+{#
+SPDX-FileCopyrightText: 2022 ImpulsoGov <contato@impulsogov.org>
+ 
+SPDX-License-Identifier: MIT
+#}
+
+WITH
+raas_psicossocial_disseminacao AS (
+    SELECT * FROM {{ ref("raas_psicossocial_disseminacao_municipios_selecionados") }}
+),
+
+habilitacoes AS (
+	SELECT DISTINCT ON (estabelecimento_id_scnes, periodo_id)
+        periodo_id,
+        periodo_data_inicio,
+        unidade_geografica_id,
+        unidade_geografica_id_sus,
+        estabelecimento_id_scnes
+    FROM {{ ref("estabelecimentos_habilitacoes_municipios_selecionados") }}
+    WHERE habilitacao_id_scnes IN (
+        '0616',	-- CAPS I	
+        '0617',	-- CAPS II	
+        '0618',	-- CAPS III	
+        '0619',	-- CAPS ALCOOL E DROGAS	
+        '0620',	-- CAPS INFANTIL
+        '0635',	-- CAPS AD III
+        '0637',	-- CAPS AD IV
+        '0621', -- SERVICO HOSPITALAR DE REFERENCIA PARA A ATENCAO INTEGRAL AOS USUARIOS DE ALCOOL E OUTRAS DROGAS
+        '0636'	-- SERVIÇOS HOSPITALARES DE REFERENCIA PARA ATENCAO A PESSOAS COM SOFRIMENTO OU TRANTORNO MENTAL INCLUINDO AQUELAS COM NECESSIDADES DECORRENTES DO USO DE ALCOOL E OUTRAS DROGAS
+    )
+),
+
+raas_distintos AS (
+    SELECT DISTINCT
+        estabelecimento_id_scnes,
+        unidade_geografica_id_sus
+    FROM raas_psicossocial_disseminacao
+),
+
+habilitacoes_caps_com_registros_sem_todos AS (
+    SELECT h.*
+    FROM habilitacoes h 
+    INNER JOIN raas_distintos rd
+    ON h.estabelecimento_id_scnes = rd.estabelecimento_id_scnes
+),
+
+habilitacoes_estabelecimento_apenas_todos AS (
+    SELECT DISTINCT ON (unidade_geografica_id_sus, periodo_data_inicio)
+        periodo_id,
+        periodo_data_inicio,
+        unidade_geografica_id,
+        unidade_geografica_id_sus,
+        '0000000' AS estabelecimento_id_scnes 
+FROM habilitacoes_caps_com_registros_sem_todos
+),
+
+habilitacoes_caps_com_registros AS (
+    SELECT * FROM habilitacoes_caps_com_registros_sem_todos
+    UNION ALL
+    SELECT * FROM habilitacoes_estabelecimento_apenas_todos
+),
+
+ausentes_ativos AS (	
+	SELECT 
+        hr.*,
+        'caps_usuarios_ativos_perfil_condicao_semsubtotais' AS tabela_referencia
+	FROM habilitacoes_caps_com_registros hr
+	LEFT JOIN (
+        SELECT DISTINCT ON (unidade_geografica_id_sus, estabelecimento_id_scnes, periodo_id) 
+            unidade_geografica_id_sus, 
+            estabelecimento_id_scnes, 
+            periodo_id
+        FROM {{ ref("_caps_usuarios_ativos_perfil_condicao_semsubtotais") }}
+    ) ref	
+	USING (unidade_geografica_id_sus, estabelecimento_id_scnes, periodo_id) 
+	WHERE ref.estabelecimento_id_scnes IS NULL AND ref.periodo_id IS NULL 
+), 
+
+ausentes_novos AS (
+	SELECT 
+        hr.*,
+        'caps_usuarios_novos_perfil_condicao' AS tabela_referencia
+	FROM habilitacoes_caps_com_registros hr
+	LEFT JOIN (
+        SELECT DISTINCT ON (unidade_geografica_id_sus, estabelecimento_id_scnes, periodo_id) 
+            unidade_geografica_id_sus, 
+            estabelecimento_id_scnes, 
+            periodo_id
+        FROM {{ ref("_caps_usuarios_novos_perfil_condicao_semsubtotais") }}
+    ) ref	
+	USING (unidade_geografica_id_sus, estabelecimento_id_scnes, periodo_id) 
+	WHERE ref.estabelecimento_id_scnes IS NULL AND ref.periodo_id IS NULL 
+),
+
+ausentes_atendimentos_individuais AS (	
+	SELECT 
+        hr.*,
+        'caps_usuarios_atendimentos_individuais_perfil_cid' AS tabela_referencia
+	FROM habilitacoes_caps_com_registros hr
+	LEFT JOIN (
+        SELECT DISTINCT ON (unidade_geografica_id_sus, estabelecimento_id_scnes, periodo_id) 
+            unidade_geografica_id_sus, 
+            estabelecimento_id_scnes, 
+            periodo_id
+        FROM {{ ref("_caps_usuarios_atendimentos_individuais_perfil_cid") }}
+    ) ref	
+	USING (unidade_geografica_id_sus, estabelecimento_id_scnes, periodo_id) 
+	WHERE ref.estabelecimento_id_scnes IS NULL AND ref.periodo_id IS NULL 
+), 
+
+ausentes_adesao AS (	
+	SELECT 
+        hr.*,
+        'caps_adesao_usuarios_perfil_cid' AS tabela_referencia
+	FROM habilitacoes_caps_com_registros hr
+	LEFT JOIN (
+        SELECT DISTINCT ON (unidade_geografica_id_sus, estabelecimento_id_scnes, periodo_id) 
+            unidade_geografica_id_sus, 
+            estabelecimento_id_scnes, 
+            periodo_id
+        FROM {{ ref("_caps_adesao_usuarios_perfil_cid") }}
+    ) ref	
+	USING (unidade_geografica_id_sus, estabelecimento_id_scnes, periodo_id) 
+	WHERE ref.estabelecimento_id_scnes IS NULL 
+        AND ref.periodo_id IS NULL 
+        AND hr.periodo_data_inicio < (
+            SELECT DATE_TRUNC('month', MAX(periodo_data_inicio)) - INTERVAL '3 months'
+            FROM habilitacoes_caps_com_registros
+    )
+), 
+
+ausentes_proced_por_usuario AS (	
+	SELECT 
+        hr.*,
+        'caps_procedimentos_por_usuario_por_tempo_servico' AS tabela_referencia
+	FROM habilitacoes_caps_com_registros hr
+	LEFT JOIN (
+        SELECT DISTINCT ON (unidade_geografica_id_sus, estabelecimento_id_scnes, periodo_id) 
+            unidade_geografica_id_sus, 
+            estabelecimento_id_scnes, 
+            periodo_id
+        FROM {{ ref("_caps_procedimentos_por_usuario_por_tempo_servico") }}
+    ) ref	
+	USING (unidade_geografica_id_sus, estabelecimento_id_scnes, periodo_id) 
+	WHERE ref.estabelecimento_id_scnes IS NULL AND ref.periodo_id IS NULL 
+), 
+
+ausentes_procedimentos_hora AS (	
+	SELECT 
+        hr.*,
+        'caps_procedimentos_por_hora_resumo' AS tabela_referencia
+	FROM habilitacoes_caps_com_registros hr
+	LEFT JOIN (
+        SELECT DISTINCT ON (unidade_geografica_id_sus, estabelecimento_id_scnes, periodo_id) 
+            unidade_geografica_id_sus, 
+            estabelecimento_id_scnes, 
+            periodo_id
+        FROM {{ ref("_caps_procedimentos_por_hora_resumo") }}
+    ) ref	
+	USING (unidade_geografica_id_sus, estabelecimento_id_scnes, periodo_id) 
+	WHERE ref.estabelecimento_id_scnes IS NULL AND ref.periodo_id IS NULL 
+), 
+
+ausentes_procedimentos_tipo AS (	
+	SELECT 
+        hr.*,
+        'caps_procedimentos_por_tipo' AS tabela_referencia
+	FROM habilitacoes_caps_com_registros hr
+	LEFT JOIN (
+        SELECT DISTINCT ON (unidade_geografica_id_sus, estabelecimento_id_scnes, periodo_id) 
+            unidade_geografica_id_sus, 
+            estabelecimento_id_scnes, 
+            periodo_id
+        FROM {{ ref("_caps_procedimentos_por_tipo") }}
+    ) ref	
+	USING (unidade_geografica_id_sus, estabelecimento_id_scnes, periodo_id) 
+	WHERE ref.estabelecimento_id_scnes IS NULL AND ref.periodo_id IS NULL 
+), 
+
+ausentes_todos AS (
+    SELECT * FROM ausentes_ativos
+    UNION ALL
+    SELECT * FROM ausentes_novos
+    UNION ALL
+    SELECT * FROM ausentes_atendimentos_individuais
+    UNION ALL
+    SELECT * FROM ausentes_adesao
+    UNION ALL
+    SELECT * FROM ausentes_proced_por_usuario
+    UNION ALL
+    SELECT * FROM ausentes_procedimentos_hora
+    UNION ALL
+    SELECT * FROM ausentes_procedimentos_tipo
+),
+
+final AS (    
+    SELECT
+		{{ dbt_utils.surrogate_key([
+			"unidade_geografica_id",
+			"unidade_geografica_id_sus",
+            "periodo_id",
+            "estabelecimento_id_scnes",
+            "tabela_referencia"
+		]) }} AS id,
+        unidade_geografica_id,
+        unidade_geografica_id_sus,
+        periodo_id,
+        periodo_data_inicio,
+        estabelecimento_id_scnes,
+        now() AS atualizacao_data,
+        tabela_referencia
+    FROM ausentes_todos
+)
+
+SELECT * FROM final

--- a/models/caps/utilitarios_configuracoes/_configuracoes_estabelecimentos_ausentes_por_periodos.sql
+++ b/models/caps/utilitarios_configuracoes/_configuracoes_estabelecimentos_ausentes_por_periodos.sql
@@ -60,7 +60,7 @@ habilitacoes_caps_com_registros AS (
     SELECT * FROM habilitacoes_estabelecimento_apenas_todos
 ),
 
-ausentes_ativos AS (	
+ausentes_ativos_perfil AS (	
 	SELECT 
         hr.*,
         'caps_usuarios_ativos_perfil_condicao_semsubtotais' AS tabela_referencia
@@ -71,6 +71,22 @@ ausentes_ativos AS (
             estabelecimento_id_scnes, 
             periodo_id
         FROM {{ ref("_caps_usuarios_ativos_perfil_condicao_semsubtotais") }}
+    ) ref	
+	USING (unidade_geografica_id_sus, estabelecimento_id_scnes, periodo_id) 
+	WHERE ref.estabelecimento_id_scnes IS NULL AND ref.periodo_id IS NULL 
+), 
+
+ausentes_ativos_resumo AS (	
+	SELECT 
+        hr.*,
+        'caps_usuarios_ativos_por_estabelecimento_resumo' AS tabela_referencia
+	FROM habilitacoes_caps_com_registros hr
+	LEFT JOIN (
+        SELECT DISTINCT ON (unidade_geografica_id_sus, estabelecimento_id_scnes, periodo_id) 
+            unidade_geografica_id_sus, 
+            estabelecimento_id_scnes, 
+            periodo_id
+        FROM {{ ref("_caps_usuarios_ativos_por_estabelecimento_resumo") }}
     ) ref	
 	USING (unidade_geografica_id_sus, estabelecimento_id_scnes, periodo_id) 
 	WHERE ref.estabelecimento_id_scnes IS NULL AND ref.periodo_id IS NULL 
@@ -199,7 +215,9 @@ ausentes_procedimentos_tipo AS (
 ), 
 
 ausentes_todos AS (
-    SELECT * FROM ausentes_ativos
+    SELECT * FROM ausentes_ativos_perfil
+    UNION ALL
+    SELECT * FROM ausentes_ativos_resumo
     UNION ALL
     SELECT * FROM ausentes_novos
     UNION ALL

--- a/models/caps/utilitarios_configuracoes/_configuracoes_estabelecimentos_ausentes_por_periodos.yml
+++ b/models/caps/utilitarios_configuracoes/_configuracoes_estabelecimentos_ausentes_por_periodos.yml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2022 Impulso Gov <contato@impulsogov.org>
+#
+# SPDX-License-Identifier: MIT
+
+
+version: 2
+
+models:
+  - name: _configuracoes_estabelecimentos_ausentes_por_periodos
+    description: >
+      Identifica quais são as competências que não possuem registros 
+      para cada combinação de município e estabelecimento, servindo 
+      como tabela preliminar para o modelo final `configuracoes_estabelecimentos_ausentes_por_periodos`.
+    config:
+      grants:
+        select: ['saude_mental_analistas', 'saude_mental_integracao']
+      alias: _configuracoes_estabelecimentos_ausentes_por_periodos
+      enabled: true
+      indexes:
+        - columns:
+          - "id"
+          unique: true
+        - columns:
+          - "unidade_geografica_id_sus"
+          - "periodo_id"
+          - "estabelecimento_id_scnes"
+      materialized: table
+      persist_docs:
+        relation: true
+      tags:
+        - "saude_mental"

--- a/models/caps/utilitarios_configuracoes/configuracoes_estabelecimentos_ausentes_por_periodos.sql
+++ b/models/caps/utilitarios_configuracoes/configuracoes_estabelecimentos_ausentes_por_periodos.sql
@@ -1,0 +1,132 @@
+{#
+SPDX-FileCopyrightText: 2022 ImpulsoGov <contato@impulsogov.org>
+ 
+SPDX-License-Identifier: MIT
+#}
+
+WITH
+estabelecimentos_ausentes AS (
+    SELECT * FROM {{ ref("_configuracoes_estabelecimentos_ausentes_por_periodos") }}
+),
+
+raas_psicossocial_disseminacao AS (
+    SELECT 
+        unidade_geografica_id_sus,
+        realizacao_periodo_data_inicio
+    FROM {{ source("siasus", "raas_psicossocial_disseminacao") }}
+),
+
+raas_ultimo_periodo AS (
+    SELECT DISTINCT ON (LEFT(unidade_geografica_id_sus, 2), realizacao_periodo_data_inicio) 
+        LEFT(unidade_geografica_id_sus, 2) as unidade_geografica_id_sus, 
+        realizacao_periodo_data_inicio as periodo_data_inicio,
+        CASE
+            WHEN realizacao_periodo_data_inicio = max_periodo THEN 'Último período'
+            ELSE (CASE
+                WHEN EXTRACT(MONTH FROM realizacao_periodo_data_inicio) = 1 THEN 'Jan/'
+                WHEN EXTRACT(MONTH FROM realizacao_periodo_data_inicio) = 2 THEN 'Fev/'
+                WHEN EXTRACT(MONTH FROM realizacao_periodo_data_inicio) = 3 THEN 'Mar/'
+                WHEN EXTRACT(MONTH FROM realizacao_periodo_data_inicio) = 4 THEN 'Abr/'
+                WHEN EXTRACT(MONTH FROM realizacao_periodo_data_inicio) = 5 THEN 'Mai/'
+                WHEN EXTRACT(MONTH FROM realizacao_periodo_data_inicio) = 6 THEN 'Jun/'
+                WHEN EXTRACT(MONTH FROM realizacao_periodo_data_inicio) = 7 THEN 'Jul/'
+                WHEN EXTRACT(MONTH FROM realizacao_periodo_data_inicio) = 8 THEN 'Ago/'
+                WHEN EXTRACT(MONTH FROM realizacao_periodo_data_inicio) = 9 THEN 'Set/'
+                WHEN EXTRACT(MONTH FROM realizacao_periodo_data_inicio) = 10 THEN 'Out/'
+                WHEN EXTRACT(MONTH FROM realizacao_periodo_data_inicio) = 11 THEN 'Nov/'
+                WHEN EXTRACT(MONTH FROM realizacao_periodo_data_inicio) = 12 THEN 'Dez/'
+            END || to_char(realizacao_periodo_data_inicio, 'YY')) 
+        END AS periodo,
+        CASE
+            WHEN realizacao_periodo_data_inicio = max_periodo_adesao THEN 'Último período'
+            WHEN realizacao_periodo_data_inicio < max_periodo_adesao THEN
+                (CASE
+                    WHEN EXTRACT(MONTH FROM realizacao_periodo_data_inicio) = 1 THEN 'Jan/'
+                    WHEN EXTRACT(MONTH FROM realizacao_periodo_data_inicio) = 2 THEN 'Fev/'
+                    WHEN EXTRACT(MONTH FROM realizacao_periodo_data_inicio) = 3 THEN 'Mar/'
+                    WHEN EXTRACT(MONTH FROM realizacao_periodo_data_inicio) = 4 THEN 'Abr/'
+                    WHEN EXTRACT(MONTH FROM realizacao_periodo_data_inicio) = 5 THEN 'Mai/'
+                    WHEN EXTRACT(MONTH FROM realizacao_periodo_data_inicio) = 6 THEN 'Jun/'
+                    WHEN EXTRACT(MONTH FROM realizacao_periodo_data_inicio) = 7 THEN 'Jul/'
+                    WHEN EXTRACT(MONTH FROM realizacao_periodo_data_inicio) = 8 THEN 'Ago/'
+                    WHEN EXTRACT(MONTH FROM realizacao_periodo_data_inicio) = 9 THEN 'Set/'
+                    WHEN EXTRACT(MONTH FROM realizacao_periodo_data_inicio) = 10 THEN 'Out/'
+                    WHEN EXTRACT(MONTH FROM realizacao_periodo_data_inicio) = 11 THEN 'Nov/'
+                    WHEN EXTRACT(MONTH FROM realizacao_periodo_data_inicio) = 12 THEN 'Dez/'
+                END || to_char(realizacao_periodo_data_inicio, 'YY')) 
+            ELSE NULL
+        END AS periodo_adesao
+    FROM (
+        SELECT distinct on (LEFT(unidade_geografica_id_sus, 2), realizacao_periodo_data_inicio) 
+            LEFT(unidade_geografica_id_sus, 2) as unidade_geografica_id_sus, 
+            realizacao_periodo_data_inicio,
+            MAX(realizacao_periodo_data_inicio) OVER () AS max_periodo,
+            MAX(realizacao_periodo_data_inicio) OVER () - INTERVAL '4 months' AS max_periodo_adesao
+        FROM raas_psicossocial_disseminacao
+    ) AS subquery
+),
+
+{{ classificar_caps_linha(
+    relacao="estabelecimentos_ausentes",
+    cte_resultado="com_linhas_estabelecimentos"
+) }},
+
+{{ nomear_estabelecimentos(
+    relacao="com_linhas_estabelecimentos",
+    coluna_estabelecimento_nome="estabelecimento",
+    cte_resultado="com_nomes_estabelecimentos"
+) }},
+
+com_datas_legiveis AS (
+    SELECT 
+        ea.*,
+        (
+            CASE 
+                WHEN tabela_referencia = 'caps_adesao_usuarios_perfil_cid' THEN rup.periodo_adesao
+                ELSE rup.periodo
+            END
+        ) AS periodo,
+        (
+            CASE
+                WHEN EXTRACT ( MONTH FROM ea.periodo_data_inicio ) = 1 THEN 'Janeiro'
+                WHEN EXTRACT ( MONTH FROM ea.periodo_data_inicio ) = 2 THEN 'Fevereiro'
+                WHEN EXTRACT ( MONTH FROM ea.periodo_data_inicio ) = 3 THEN 'Março'
+                WHEN EXTRACT ( MONTH FROM ea.periodo_data_inicio ) = 4 THEN 'Abril'
+                WHEN EXTRACT ( MONTH FROM ea.periodo_data_inicio ) = 5 THEN 'Maio'
+                WHEN EXTRACT ( MONTH FROM ea.periodo_data_inicio ) = 6 THEN 'Junho'
+                WHEN EXTRACT ( MONTH FROM ea.periodo_data_inicio ) = 7 THEN 'Julho'
+                WHEN EXTRACT ( MONTH FROM ea.periodo_data_inicio ) = 8 THEN 'Agosto'
+                WHEN EXTRACT ( MONTH FROM ea.periodo_data_inicio ) = 9 THEN 'Setembro'
+                WHEN EXTRACT ( MONTH FROM ea.periodo_data_inicio ) = 10 THEN 'Outubro'
+                WHEN EXTRACT ( MONTH FROM ea.periodo_data_inicio ) = 11 THEN 'Novembro'
+                WHEN EXTRACT ( MONTH FROM ea.periodo_data_inicio ) = 12 THEN 'Dezembro'
+            END
+        ) AS nome_mes,
+        (
+            to_char(ea.periodo_data_inicio, 'YY')::numeric + EXTRACT ( MONTH FROM ea.periodo_data_inicio )/100
+        ) AS periodo_ordem
+    FROM com_nomes_estabelecimentos ea
+    LEFT JOIN raas_ultimo_periodo rup
+    ON (LEFT(ea.unidade_geografica_id_sus, 2)) = rup.unidade_geografica_id_sus
+    AND ea.periodo_data_inicio = rup.periodo_data_inicio
+),
+
+final AS (
+    SELECT
+        id,
+        unidade_geografica_id,
+        unidade_geografica_id_sus,
+        estabelecimento_linha_perfil,
+        estabelecimento_linha_idade,
+        estabelecimento,
+        periodo_id,
+        periodo_data_inicio AS competencia,
+        periodo,
+        nome_mes,
+        periodo_ordem,        
+        tabela_referencia,
+        atualizacao_data
+    FROM com_datas_legiveis
+)
+
+SELECT * FROM final

--- a/models/caps/utilitarios_configuracoes/configuracoes_estabelecimentos_ausentes_por_periodos.sql
+++ b/models/caps/utilitarios_configuracoes/configuracoes_estabelecimentos_ausentes_por_periodos.sql
@@ -83,6 +83,7 @@ com_datas_legiveis AS (
         (
             CASE 
                 WHEN tabela_referencia = 'caps_adesao_usuarios_perfil_cid' THEN rup.periodo_adesao
+                WHEN tabela_referencia = 'caps_adesao_evasao_coortes_resumo' THEN rup.periodo_adesao
                 ELSE rup.periodo
             END
         ) AS periodo,

--- a/models/caps/utilitarios_configuracoes/configuracoes_estabelecimentos_ausentes_por_periodos.yml
+++ b/models/caps/utilitarios_configuracoes/configuracoes_estabelecimentos_ausentes_por_periodos.yml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2022 Impulso Gov <contato@impulsogov.org>
+#
+# SPDX-License-Identifier: MIT
+
+
+version: 2
+
+models:
+  - name: configuracoes_estabelecimentos_ausentes_por_periodos
+    description: >
+      Assim como o modelo '_configuracoes_estabelecimentos_ausentes_por_periodos',
+      identifica quais são as competências que não possuem registros 
+      para cada combinação de município e estabelecimento. Acrescido
+      de lógica para identificar qual o real último período de envio de
+      dados do estado, serve como Tabela Referência para listagem de 
+      períodos faltantes que deverão ser adicionados via front/back end 
+      da plataforma, sendo assim possível mostrar todas as competências 
+      no painel, mesmo quando zeradas.
+    config:
+      grants:
+        select: ['saude_mental_analistas', 'saude_mental_integracao']
+      alias: configuracoes_estabelecimentos_ausentes_por_periodos
+      enabled: true
+      indexes:
+        - columns:
+          - "id"
+          unique: true
+        - columns:
+          - "unidade_geografica_id_sus"
+          - "periodo"
+          - "estabelecimento"
+      materialized: table
+      persist_docs:
+        relation: true
+      tags:
+        - "saude_mental"

--- a/models/sources/scnes.yml
+++ b/models/sources/scnes.yml
@@ -32,3 +32,9 @@ sources:
           profissionais/prestadores de serviços e estabelecimentos de saúde
           registrados no Sistema do Cadastro Nacional de Estabelecimentos de
           Saúde (SCNES).
+
+      - name: estabelecimentos_habilitacoes
+        identifier: scnes_habilitacoes_disseminacao
+        description: >
+          Arquivo de disseminação com dados de habilitação dos estabelecimentos 
+          de saúde registrados no Cadastro Nacional de Estabelecimentos de Saúde (CNES).

--- a/models/sources/scnes.yml
+++ b/models/sources/scnes.yml
@@ -26,7 +26,7 @@ sources:
         description: Informações dos estabelecimentos de saúde identificados.
 
       - name: vinculos_profissionais
-        identifier: scnes_vinculos_disseminacao
+        identifier: sm_scnes_vinculos_disseminacao
         description: >
           Arquivo de disseminação com dados de vínculos entre
           profissionais/prestadores de serviços e estabelecimentos de saúde
@@ -34,7 +34,7 @@ sources:
           Saúde (SCNES).
 
       - name: estabelecimentos_habilitacoes
-        identifier: scnes_habilitacoes_disseminacao
+        identifier: sm_scnes_habilitacoes_disseminacao
         description: >
           Arquivo de disseminação com dados de habilitação dos estabelecimentos 
           de saúde registrados no Cadastro Nacional de Estabelecimentos de Saúde (CNES).

--- a/models/sources/siasus.yml
+++ b/models/sources/siasus.yml
@@ -23,21 +23,21 @@ sources:
     tables:
 
       - name: bpa_i_disseminacao
-        identifier: siasus_bpa_i_disseminacao_sm_complemento
+        identifier: sm_siasus_bpa_i_disseminacao
         description: >
           Arquivo de disseminação dos Boletins de Produção Ambulatorial 
           individualizados (BPA-i) do Sistema de Informações Ambulatoriais do
           SUS (SIASUS).
 
       - name: procedimentos_disseminacao
-        identifier: siasus_procedimentos_ambulatoriais_sm_complemento
+        identifier: sm_siasus_procedimentos_ambulatoriais
         description: >
           Arquivo de disseminação dos procedimentos do Sistema de Informações
           Ambulatoriais do SUS (SIASUS), incluindo informações resumidas de
           diversos documentos (BPA-i, BPA-c, RAAS-PS, RAAS-AD, APAC-P, APAC-S).
 
       - name: raas_psicossocial_disseminacao
-        identifier: _siasus_raas_psicossocial_disseminacao
+        identifier: sm_siasus_raas_psicossocial_disseminacao
         description: >
           Arquivo de disseminação dos Registros das Ações Ambulatorias de Saúde
           - Psicossociais (RAAS-PS) do Sistema de Informações Ambulatoriais do

--- a/models/sources/sihsus.yml
+++ b/models/sources/sihsus.yml
@@ -22,7 +22,7 @@ sources:
     tables:
 
       - name: aih_rd_disseminacao
-        identifier: _sihsus_aih_reduzida_disseminacao
+        identifier: sm_sihsus_aih_reduzida_disseminacao
         description: >
           Arquivos de disseminação das Autorizações de Internação Hospitalar
           Reduzidas (AIH-RD), conforme disponibilizadas no FTP público do

--- a/models/sources_apenas_municipios_participantes/aih_rd_disseminacao_municipios_selecionados.sql
+++ b/models/sources_apenas_municipios_participantes/aih_rd_disseminacao_municipios_selecionados.sql
@@ -129,18 +129,8 @@ aih_rd_disseminacao AS (
     FROM {{ source("sihsus", "aih_rd_disseminacao") }}    
 ),
 
-{{ selecionar_municipios_ativos(
-	relacao="aih_rd_disseminacao",
-	cte_resultado="municipios_selecionados"
-) }},
-
-{{ remover_estabelecimentos_indesejados(
-	relacao="municipios_selecionados",
-	cte_resultado="municipios_selecionados_filtrados"
-) }},
-
 {{ limitar_quantidade_meses(
-	relacao="municipios_selecionados_filtrados",
+	relacao="aih_rd_disseminacao",
     coluna_data="periodo_data_inicio",
 	cte_resultado="final"
 ) }}

--- a/models/sources_apenas_municipios_participantes/estabelecimentos_habilitacoes_municipios_selecionados.sql
+++ b/models/sources_apenas_municipios_participantes/estabelecimentos_habilitacoes_municipios_selecionados.sql
@@ -46,7 +46,7 @@ estabelecimentos_habilitacoes AS (
         id,
         CAST(periodo_id AS UUID) AS periodo_id,
         CAST(unidade_geografica_id AS UUID) AS unidade_geografica_id
-    FROM {{ source("scnes", "estabelecimentos_habilitacoes") }}    
+    FROM {{ source("scnes", "estabelecimentos_habilitacoes") }} 
 ),
 
 {{ selecionar_municipios_ativos(
@@ -66,3 +66,5 @@ estabelecimentos_habilitacoes AS (
 ) }}
 
 SELECT * FROM final
+-- trecho necessário para evitar bugs na tabela de configuracoes_estabelecimentos_ausentes_por_periodos
+WHERE periodo_data_inicio <= (SELECT max (periodo_data_inicio) AS max_periodo_data_inicio FROM {{ ref("raas_psicossocial_disseminacao_ultima_competencia") }})

--- a/models/sources_apenas_municipios_participantes/estabelecimentos_habilitacoes_municipios_selecionados.sql
+++ b/models/sources_apenas_municipios_participantes/estabelecimentos_habilitacoes_municipios_selecionados.sql
@@ -1,0 +1,68 @@
+
+{#
+SPDX-FileCopyrightText: 2022 ImpulsoGov <contato@impulsogov.org>
+ 
+SPDX-License-Identifier: MIT
+#}
+
+
+WITH
+estabelecimentos_habilitacoes AS (
+	SELECT 
+        estabelecimento_id_scnes,
+        estabelecimento_municipio_id_sus AS unidade_geografica_id_sus,
+        -- estabelecimento_regiao_saude_id_sus,
+        /* estabelecimento_microrregiao_saude_id_sus,
+        estabelecimento_distrito_sanitario_id_sus,
+        estabelecimento_distrito_administrativo_id_sus,
+        estabelecimento_gestao_condicao_id_scnes,
+        estabelecimento_personalidade_juridica_id_scnes,
+        estabelecimento_id_cpf_cnpj,
+        estabelecimento_mantido,
+        estabelecimento_mantenedora_id_cnpj,
+        estabelecimento_esfera_id_scnes,
+        estabelecimento_tributos_retencao_id_scnes,
+        estabelecimento_atividade_ensino_id_scnes, */
+        estabelecimento_natureza_id_scnes,
+        -- estabelecimento_fluxo_id_scnes,
+        estabelecimento_tipo_id_scnes,
+        estabelecimento_turno_id_scnes,
+        estabelecimento_hierarquia_id_scnes,
+        -- estabelecimento_terceiro,
+        -- estabelecimento_cep,
+        atendimento_sus,
+        -- prestador_tipo_id_fca,
+        habilitacao_id_scnes,
+        vigencia_data_inicio,
+        vigencia_data_fim,
+        -- portaria_data,
+        -- portaria_nome,
+        -- portaria_periodo_data_inicio,
+        -- leitos_quantidade,
+        CAST(periodo_data_inicio AS DATE) AS periodo_data_inicio,
+        estabelecimento_natureza_juridica_id_scnes,
+        criacao_data,
+        atualizacao_data,
+        id,
+        CAST(periodo_id AS UUID) AS periodo_id,
+        CAST(unidade_geografica_id AS UUID) AS unidade_geografica_id
+    FROM {{ source("scnes", "estabelecimentos_habilitacoes") }}    
+),
+
+{{ selecionar_municipios_ativos(
+	relacao="estabelecimentos_habilitacoes",
+	cte_resultado="municipios_selecionados"
+) }},
+
+{{ remover_estabelecimentos_indesejados(
+	relacao="municipios_selecionados",
+	cte_resultado="municipios_selecionados_filtrados"
+) }},
+
+{{ limitar_quantidade_meses(
+	relacao="municipios_selecionados_filtrados",
+    coluna_data="periodo_data_inicio",
+	cte_resultado="final"
+) }}
+
+SELECT * FROM final

--- a/models/sources_apenas_municipios_participantes/estabelecimentos_habilitacoes_municipios_selecionados.yml
+++ b/models/sources_apenas_municipios_participantes/estabelecimentos_habilitacoes_municipios_selecionados.yml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2022 Impulso Gov <contato@impulsogov.org>
+#
+# SPDX-License-Identifier: MIT
+
+
+version: 2
+
+models:
+  - name: estabelecimentos_habilitacoes_municipios_selecionados
+    description: >
+      [...]
+    config:
+      grants:
+        select: ['saude_mental_analistas', 'saude_mental_integracao']
+      alias: estabelecimentos_habilitacoes_municipios_selecionados
+      enabled: true
+      indexes:
+        - columns: 
+          - "periodo_data_inicio"
+        - columns:
+          - "unidade_geografica_id"
+          - "unidade_geografica_id_sus"
+          - "periodo_data_inicio"
+      materialized: table
+      persist_docs:
+        relation: true
+      tags:
+        - "saude_mental"
+        - "scnes"
+        - "municipios_painel"


### PR DESCRIPTION
# Descrição de contexto
É comum que municípios possuam problemas de registro em meses específicos, realizando o envio de dados com algum estabelecimento faltante ou não realizando o envio, resultando na ausência completa de um ou mais estabelecimentos nas tabelas baixadas via ETL e armazenadas em `dados_publicos`.

Ao executar o DBT para gerar as tabelas de indicadores, utilizando como fonte de dados as tabelas armazenadas em `dados_publicos`, o resultado final apresenta a total ausência de competências inteiras, quando o caso é o mencionado anteriormente (ausência completa de envio de dados naquele mês específico). Quando isso acontece, a competência em questão por completo não aparece no painel de indicadores

## Por que isso é um problema?
A primeira vista, a ausência de competências deixa ao usuário final a percepção de que o painel está incompleto, que essas competências não foram inseridas no site pela Impulso. 

Manter sempre visível todas as competências, mesmo quando zeradas, devolve o problema ao usuário final: se o dado está zerado na plataforma, fica mais fácil entender que ele é um problema de registro e não da plataforma em si.

Apesar do problema ter sido observado durante teste para liberação da plataforma ao município de Monteiro, é imprescindível entender que esse comportamento de dados pode estar ocorrendo para qualquer município/estabelecimento em qualquer competência passada, e pode vir a ocorrer em qualquer competência futura, uma vez que o que gera a ausência completa de uma competência no indicador final é fruto da ausência total de registros baixados para aquela mesma competência.

# Objetivo 
O objetivo desse PR consiste na criação de uma tabela de referência (TR) que contem o indicativo (para cada uma das tabelas de indicadores utilizada pela API para preencher os filtros de períodos) de qual o município, estabelecimento e período que falta dados.
- Para a listagem de períodos que deveriam ter dados por município/estabelecimento (independente de terem tido envios de dados ou não) foi utilizado como referência os estabelecimentos habilitados como CAPS para cada competência, em conjunto com a listagem de unidades federativas que tiveram ao menos um procedimento registrado em RAAS.

> Obs: É a partir da TR que será inserido via modificações no front o estabelecimento e a competência nos filtros do painel, além de um texto indicativo quando essa combinação estabelecimento x filtro for selecionada.

 [feat: ✨ Cria modelo que identifica competências sem registro por município, estabelecimento e período](https://github.com/ImpulsoGov/saude-mental-indicadores/pull/33/commits/6c956c1acd175b8e1a3ed5be132611521a9b2206) 
 
 [feat: ✨ Adiciona fonte de dados de habilitações](https://github.com/ImpulsoGov/saude-mental-indicadores/pull/33/commits/36bc3bdc685c0d8b76e4b2002f480570289e609b)

## Objetivos secundários
- Garantir que a TR mostre texto de `Último período` na coluna `periodo` sempre que realmente for o último período de dados que está faltando para aquele município (ou seja, que o pacote estadual de dados mais recente foi baixado, mas o município em questão não apresentou produção na competência). 
- Garantir que as Tabelas de Indicadores (TI) mostrem o texto `Último período` apenas quando realmente for o último período real (considerando o último processamento de dados estatal). 
    - No formato anterior, o texto `Último período` era inserido nas TIs selecionando o último período presente na tabela, por município. Ou seja, antes da modificação, caso a última competência estatal fosse fev/24, mas o município tivesse deixado de enviar dados em fev/24 e jan/24, o texto `Último período` apareceria no mês de dez/23. Com a alteração, o texto não aparecerá para esses casos.

[fix: ✨ Altera macros para inserir texto 'Último período' apenas quando for o real último período do estado](https://github.com/ImpulsoGov/saude-mental-indicadores/pull/33/commits/7b9aa640d538dd6081701e2ae23df27ba6bf6932)

[refactor: ♻️ Altera modelo de resumo de CAPS para não utilizar como critério de filtragem texto de período](https://github.com/ImpulsoGov/saude-mental-indicadores/pull/33/commits/ffedfc93edb737083d4d919b4d46a591e6bae61d)

[fix: 🐛 Remove trecho de código que limita municípios/remove estabelecimentos para evitar bug em indicador de internação](https://github.com/ImpulsoGov/saude-mental-indicadores/pull/33/commits/26909d3ae24cc95a5a679e282eb6396e9bca1314)

[fix: 🐛 Corrige bug para tabelas de coortes de adesão](https://github.com/ImpulsoGov/saude-mental-indicadores/pull/33/commits/75bf5977c6ca3f292a7f65e71129e86adbef3fd4)





